### PR TITLE
Affiliation and completed webhook

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -32,6 +32,7 @@ define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_ENABLE', 'gtm_server_side_webhooks_enabl
 define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_CONTAINER_URL', 'gtm_server_side_webhooks_container_url' );
 define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_PURCHASE', 'gtm_server_side_webhooks_purchase' );
 define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_PROCESSING', 'gtm_server_side_webhooks_processing' );
+define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED', 'gtm_server_side_webhooks_completed' );
 define( 'GTM_SERVER_SIDE_FIELD_WEBHOOKS_REFUND', 'gtm_server_side_webhooks_refund' );
 
 define( 'GTM_SERVER_SIDE_FIELD_PLACEMENT_VALUE_CODE', 'code' );

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -32,6 +32,7 @@ add_action( 'init', array( GTM_Server_Side_Plugin_Upgrade::class, 'instance' ) )
 add_action( 'gtm_server_side', array( GTM_Server_Side_I18n::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Webhook_Purchase::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Webhook_Processing::class, 'instance' ) );
+add_action( 'gtm_server_side', array( GTM_Server_Side_Webhook_Completed::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Webhook_Refund::class, 'instance' ) );
 add_action( 'gtm_server_side_admin', array( GTM_Server_Side_Admin_Settings::class, 'instance' ) );
 add_action( 'gtm_server_side_admin', array( GTM_Server_Side_Admin_Ajax::class, 'instance' ) );

--- a/includes/class-gtm-server-side-admin-ajax.php
+++ b/includes/class-gtm-server-side-admin-ajax.php
@@ -104,7 +104,7 @@ class GTM_Server_Side_Admin_Ajax {
 			'event'     => 'purchase',
 			'ecommerce' => array(
 				'transaction_id' => '358',
-				'affiliation'    => 'test',
+				'affiliation'    => apply_filters('gtm_server_side_order_affiliation','test', null),
 				'value'          => 18.00,
 				'tax'            => 0,
 				'shipping'       => 0,
@@ -148,7 +148,7 @@ class GTM_Server_Side_Admin_Ajax {
 			'event'     => 'order_paid',
 			'ecommerce' => array(
 				'transaction_id' => '358',
-				'affiliation'    => 'test',
+				'affiliation'    => apply_filters('gtm_server_side_order_affiliation','test', null),
 				'value'          => 18.00,
 				'tax'            => 0,
 				'shipping'       => 0,

--- a/includes/class-gtm-server-side-admin-settings.php
+++ b/includes/class-gtm-server-side-admin-settings.php
@@ -455,6 +455,29 @@ class GTM_Server_Side_Admin_Settings {
 			GTM_SERVER_SIDE_ADMIN_SLUG,
 			GTM_SERVER_SIDE_ADMIN_GROUP_WEBHOOKS
 		);
+		register_setting(
+			GTM_SERVER_SIDE_ADMIN_GROUP,
+			GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED,
+			array(
+				'sanitize_callback' => 'GTM_Server_Side_Helpers::sanitize_bool',
+			)
+		);
+		add_settings_field(
+			GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED,
+			__( 'Order paid webhook', 'gtm-server-side' ),
+			function() {
+				echo '<input
+					type="checkbox"
+					id="' . esc_attr( GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED ) . '"
+					name="' . esc_attr( GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED ) . '"
+					' . checked( GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED ), 'yes', false ) . '
+					value="yes">';
+					echo '<br>';
+					printf( __( 'Order paid event will be sent whenever an order is paid (has "Completed" status as per <a href="%s" target="_blank">Woocommerce documentation</a>).', 'gtm-server-side' ), 'https://woocommerce.com/document/managing-orders/order-statuses/' ); // phpcs:ignore
+			},
+			GTM_SERVER_SIDE_ADMIN_SLUG,
+			GTM_SERVER_SIDE_ADMIN_GROUP_WEBHOOKS
+		);
 
 		register_setting(
 			GTM_SERVER_SIDE_ADMIN_GROUP,

--- a/includes/class-gtm-server-side-event-purchase.php
+++ b/includes/class-gtm-server-side-event-purchase.php
@@ -86,7 +86,7 @@ class GTM_Server_Side_Event_Purchase {
 			'ecomm_pagetype' => 'purchase',
 			'ecommerce'      => array(
 				'transaction_id'  => esc_attr( $order->get_order_number() ),
-				'affiliation'     => '',
+				'affiliation'     => apply_filters('gtm_server_side_order_affiliation','', $order),
 				'value'           => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'             => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),
 				'shipping'        => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_shipping_total() ),

--- a/includes/class-gtm-server-side-webhook-completed.php
+++ b/includes/class-gtm-server-side-webhook-completed.php
@@ -10,9 +10,9 @@
 defined( 'ABSPATH' ) || exit;
 
 /**
- * Webhook Processing.
+ * Webhook Completed.
  */
-class GTM_Server_Side_Webhook_Processing {
+class GTM_Server_Side_Webhook_Completed {
 	use GTM_Server_Side_Singleton;
 
 	/**
@@ -25,21 +25,21 @@ class GTM_Server_Side_Webhook_Processing {
 			return;
 		}
 
-		add_action( 'woocommerce_order_status_processing', array( $this, 'woocommerce_order_status_processing' ) );
+		add_action( 'woocommerce_order_status_completed', array( $this, 'woocommerce_order_status_completed' ) );
 	}
 
 	/**
-	 * Order change status to processing (Order paid).
+	 * Order change status to completed (Final status of Order).
 	 *
 	 * @param  int $order_id Order id.
 	 * @return void
 	 */
-	public function woocommerce_order_status_processing( $order_id ) {
+	public function woocommerce_order_status_completed( $order_id ) {
 		if ( ! GTM_Server_Side_Helpers::is_enable_webhook() ) {
 			return;
 		}
 
-		if ( GTM_SERVER_SIDE_FIELD_VALUE_YES !== GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_WEBHOOKS_PROCESSING ) ) {
+		if ( GTM_SERVER_SIDE_FIELD_VALUE_YES !== GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_WEBHOOKS_COMPLETED ) ) {
 			return;
 		}
 

--- a/includes/class-gtm-server-side-webhook-purchase.php
+++ b/includes/class-gtm-server-side-webhook-purchase.php
@@ -52,7 +52,7 @@ class GTM_Server_Side_Webhook_Purchase {
 			'event'     => 'purchase',
 			'ecommerce' => array(
 				'transaction_id' => esc_attr( $order->get_order_number() ),
-				'affiliation'    => '',
+				'affiliation'    => apply_filters('gtm_server_side_order_affiliation','', $order),
 				'value'          => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'            => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),
 				'shipping'       => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_shipping_total() ),


### PR DESCRIPTION
1. Implement Completed webhook to order_paid event (instead of only "processing" status)

2. Add filter "gtm_server_side_order_affiliation" to allow affiliation field inside data layer, parameters are default value ("test" to test, and "" to others), $order object (null when using at "test")