### PR TITLE
add filters to processing, purchase and refund webhooks to allow payload data alterations

### DIFF
--- a/includes/class-gtm-server-side-webhook-processing.php
+++ b/includes/class-gtm-server-side-webhook-processing.php
@@ -73,6 +73,14 @@ class GTM_Server_Side_Webhook_Processing {
 			}
 		}
 
+		/**
+		 * Allows modification of processing order webhook payload.
+		 *
+		 * @param array  $request Webhook payload data.
+		 * @param object $order   WC_Order instance.
+		 */
+		$request = apply_filters( 'gtm_server_side_processing_webhook_payload', $request, $order );
+
 		GTM_Server_Side_Helpers::send_webhook_request( $request );
 	}
 }

--- a/includes/class-gtm-server-side-webhook-purchase.php
+++ b/includes/class-gtm-server-side-webhook-purchase.php
@@ -73,6 +73,14 @@ class GTM_Server_Side_Webhook_Purchase {
 			}
 		}
 
+		/**
+		 * Allows modification of purchase webhook payload.
+		 *
+		 * @param array  $request Webhook payload data.
+		 * @param object $order   WC_Order instance.
+		 */
+		$request = apply_filters( 'gtm_server_side_purchase_webhook_payload', $request, $order );
+
 		GTM_Server_Side_Helpers::send_webhook_request( $request );
 	}
 }

--- a/includes/class-gtm-server-side-webhook-refund.php
+++ b/includes/class-gtm-server-side-webhook-refund.php
@@ -60,6 +60,14 @@ class GTM_Server_Side_Webhook_Refund {
 			'user_data' => GTM_Server_Side_WC_Helpers::instance()->get_order_user_data( $order ),
 		);
 
+		/**
+		 * Allows modification of refund webhook payload.
+		 *
+		 * @param array  $request Webhook payload data.
+		 * @param object $order   WC_Order instance.
+		 */
+		$request = apply_filters( 'gtm_server_side_refund_webhook_payload', $request, $order );
+
 		GTM_Server_Side_Helpers::send_webhook_request( $request );
 	}
 }


### PR DESCRIPTION
Resolves #17

Proposed changes:

Instead of creating catch all filter in GTM_Server_Side_Helpers::send_webhook_request() I've opted to add individual filters because:
1. We already have the $order data and can pass it to the filter, which, in turn, won't need to be queried again.
2. We can create searchable filter names instead of parsing payload data and creating filter names on dynamically (harder to search).
3. We keep GTM_Server_Side_Helpers::send_webhook_request() method as is, without passing irrelevant order data.