### PR TITLE
Use order item price instead of product price

### DIFF
--- a/includes/class-gtm-server-side-wc-helpers.php
+++ b/includes/class-gtm-server-side-wc-helpers.php
@@ -101,6 +101,7 @@ class GTM_Server_Side_WC_Helpers {
 			}
 
 			$array             = $this->get_data_layer_item( $product );
+			$array['price']    = round( $item_loop->get_total() / $item_loop->get_quantity(), wc_get_price_decimals() );
 			$array['quantity'] = intval( $item_loop->get_quantity() );
 			$array['index']    = $index++;
 


### PR DESCRIPTION
Closes #26 

As get_data_layer_item() method is used by add to cart and view item events (not affected by the bug), the proposed fix just overwrites the price value inside get_order_data_layer_items() itself.

I've opted for rounding with wc_get_price_decimals() as argument to support non-decimal currencies as well. This will still cause small discrepancies due to rounding errors, but those will be significantly smaller than what we have right now.

I'm open to make additional changes if needed.