### PR TITLE
Prevent dynamic data from being output on cached pages

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -43,6 +43,7 @@ define( 'GTM_SERVER_SIDE_ADMIN_GROUP', 'gtm-server-side-admin-group' );
 define( 'GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL', 'gtm-server-side-admin-group-general' );
 define( 'GTM_SERVER_SIDE_ADMIN_GROUP_DATA_LAYER', 'gtm-server-side-admin-group-data-layer' );
 define( 'GTM_SERVER_SIDE_ADMIN_GROUP_WEBHOOKS', 'gtm-server-side-admin-group-webhooks' );
+define( 'GTM_SENSITIVE_DATA_NOTICE', '<!-- DO NOT CACHE -->' );
 
 // Autoload plugin classes.
 spl_autoload_register(

--- a/includes/class-gtm-server-side-admin-settings.php
+++ b/includes/class-gtm-server-side-admin-settings.php
@@ -271,7 +271,7 @@ class GTM_Server_Side_Admin_Settings {
 					' . checked( GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_DATA_LAYER_ECOMMERCE ), 'yes', false ) . '
 					value="yes">';
 				echo '<br>';
-				esc_html_e( 'This option only works with Woocommerce shops. Adds basic events and their data: Login, SignUp, ViewItem, AddToCart, BeginCheckout, Purchase.', 'gtm-server-side' );
+				esc_html_e( 'This option only works with Woocommerce shops. Adds basic events and their data: Login, SignUp, ViewItem, AddToCart, BeginCheckout, Purchase. On cached websites ensure to implement gtm_server_side_is_page_cached filter.', 'gtm-server-side' );
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG,
 			GTM_SERVER_SIDE_ADMIN_GROUP_DATA_LAYER
@@ -295,7 +295,7 @@ class GTM_Server_Side_Admin_Settings {
 					' . checked( GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_DATA_LAYER_USER_DATA ), 'yes', false ) . '
 					value="yes">';
 				echo '<br>';
-				esc_html_e( 'All events for authorised users will have their personal details (name, surname, email, etc.) available. Their billing details will be available on the purchase event.', 'gtm-server-side' );
+				esc_html_e( 'All events for authorised users on uncached pages, will have their personal details (name, surname, email, etc.) available. Their billing details will be available on the purchase event. Page is marked as cached using `gtm_server_side_is_page_cached` filter.', 'gtm-server-side' );
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG,
 			GTM_SERVER_SIDE_ADMIN_GROUP_DATA_LAYER

--- a/includes/class-gtm-server-side-event-begincheckout.php
+++ b/includes/class-gtm-server-side-event-begincheckout.php
@@ -34,6 +34,10 @@ class GTM_Server_Side_Event_BeginCheckout {
 	 * @return void
 	 */
 	public function wp_footer() {
+		if ( ! GTM_Server_Side_Helpers::can_output_sensitive_data() ) {
+			return;
+		}
+
 		if ( ! is_checkout() ) {
 			return;
 		}
@@ -55,9 +59,10 @@ class GTM_Server_Side_Event_BeginCheckout {
 			),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
 		}
+		echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 		<script type="text/javascript">
 			dataLayer.push( { ecommerce: null } );

--- a/includes/class-gtm-server-side-event-login.php
+++ b/includes/class-gtm-server-side-event-login.php
@@ -52,6 +52,10 @@ class GTM_Server_Side_Event_Login {
 	 * @return void
 	 */
 	public function wp_footer() {
+		if ( ! GTM_Server_Side_Helpers::can_output_sensitive_data() ) {
+			return;
+		}
+
 		if ( ! GTM_Server_Side_Helpers::exists_session( self::CHECK_NAME, GTM_SERVER_SIDE_FIELD_VALUE_YES ) ) {
 			return;
 		}
@@ -60,10 +64,11 @@ class GTM_Server_Side_Event_Login {
 			'event' => GTM_Server_Side_Helpers::get_data_layer_event_name( 'login' ),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
 		}
-		?>
+		echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+        ?>
 		<script type="text/javascript">
 			dataLayer.push( { ecommerce: null } );
 			dataLayer.push(<?php echo GTM_Server_Side_Helpers::array_to_json( $data_layer ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped ?>);

--- a/includes/class-gtm-server-side-event-purchase.php
+++ b/includes/class-gtm-server-side-event-purchase.php
@@ -65,6 +65,10 @@ class GTM_Server_Side_Event_Purchase {
 	 * @return void
 	 */
 	public function wp_footer() {
+		if ( ! GTM_Server_Side_Helpers::can_output_sensitive_data() ) {
+			return;
+		}
+
 		/* phpcs:ignore
 		if ( ! is_wc_endpoint_url( 'order-received' ) ) {
 			return;
@@ -97,10 +101,11 @@ class GTM_Server_Side_Event_Purchase {
 			),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data']                 = GTM_Server_Side_WC_Helpers::instance()->get_order_user_data( $order );
 			$data_layer['user_data']['new_customer'] = GTM_Server_Side_WC_Helpers::instance()->is_new_customer( $order->get_customer_id() ) ? 'true' : 'false';
 		}
+		echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 		<script type="text/javascript">
 			dataLayer.push( { ecommerce: null } );

--- a/includes/class-gtm-server-side-event-register.php
+++ b/includes/class-gtm-server-side-event-register.php
@@ -52,6 +52,10 @@ class GTM_Server_Side_Event_Register {
 	 * @return void
 	 */
 	public function wp_footer() {
+		if ( ! GTM_Server_Side_Helpers::can_output_sensitive_data() ) {
+			return;
+		}
+
 		if ( ! GTM_Server_Side_Helpers::exists_session( self::CHECK_NAME, GTM_SERVER_SIDE_FIELD_VALUE_YES ) ) {
 			return;
 		}
@@ -60,9 +64,10 @@ class GTM_Server_Side_Event_Register {
 			'event' => GTM_Server_Side_Helpers::get_data_layer_event_name( 'sign_up' ),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
 		}
+		echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 		<script type="text/javascript">
 			dataLayer.push( { ecommerce: null } );

--- a/includes/class-gtm-server-side-event-viewcart.php
+++ b/includes/class-gtm-server-side-event-viewcart.php
@@ -34,6 +34,9 @@ class GTM_Server_Side_Event_ViewCart {
 	 * @return void
 	 */
 	public function wp_footer() {
+		if ( ! GTM_Server_Side_Helpers::can_output_sensitive_data() ) {
+			return;
+		}
 		if ( ! is_cart() ) {
 			return;
 		}
@@ -56,9 +59,10 @@ class GTM_Server_Side_Event_ViewCart {
 			),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
 		}
+		echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		?>
 		<script type="text/javascript">
 			dataLayer.push( { ecommerce: null } );

--- a/includes/class-gtm-server-side-event-viewitem.php
+++ b/includes/class-gtm-server-side-event-viewitem.php
@@ -56,8 +56,9 @@ class GTM_Server_Side_Event_ViewItem {
 			),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
+			echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 		?>
 		<script type="text/javascript">

--- a/includes/class-gtm-server-side-event-viewitemlist.php
+++ b/includes/class-gtm-server-side-event-viewitemlist.php
@@ -52,8 +52,9 @@ class GTM_Server_Side_Event_ViewItemList {
 			),
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$data_layer['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
+			echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 		?>
 		<script type="text/javascript">

--- a/includes/class-gtm-server-side-frontend-assets.php
+++ b/includes/class-gtm-server-side-frontend-assets.php
@@ -42,8 +42,9 @@ class GTM_Server_Side_Frontend_Assets {
 			'DATA_LAYER_CUSTOM_EVENT_NAME' => GTM_SERVER_SIDE_DATA_LAYER_CUSTOM_EVENT_NAME,
 		);
 
-		if ( GTM_Server_Side_WC_Helpers::instance()->is_enable_user_data() ) {
+		if ( GTM_Server_Side_WC_Helpers::instance()->should_output_user_data() ) {
 			$scripts['user_data'] = GTM_Server_Side_WC_Helpers::instance()->get_data_layer_user_data();
+			echo GTM_SENSITIVE_DATA_NOTICE; // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 		}
 
 		wp_localize_script( 'gtm-server-side', 'varGtmServerSide', $scripts );

--- a/includes/class-gtm-server-side-helpers.php
+++ b/includes/class-gtm-server-side-helpers.php
@@ -56,6 +56,13 @@ class GTM_Server_Side_Helpers {
 	private static $is_stape_analytics_support;
 
 	/**
+	 * Cache detection result.
+	 *
+	 * @var bool|null
+	 */
+	private static $is_page_cached;
+
+	/**
 	 * Get attr option.
 	 *
 	 * @param string $option The option ID.
@@ -619,5 +626,27 @@ class GTM_Server_Side_Helpers {
 	 */
 	public static function delete_cache_field( $key ) {
 		delete_transient( $key . '__generated' );
+	}
+
+	/**
+	 * Check if the current page is cached.
+	 *
+	 * @return bool
+	 */
+	public static function is_page_cached() {
+		if ( null === static::$is_page_cached ) {
+			static::$is_page_cached = apply_filters( 'gtm_server_side_is_page_cached', false );
+		}
+
+		return static::$is_page_cached;
+	}
+
+	/**
+	 * Check if sensitive data can be output (not on cached pages).
+	 *
+	 * @return bool
+	 */
+	public static function can_output_sensitive_data() {
+		return ! static::is_page_cached();
 	}
 }

--- a/includes/class-gtm-server-side-wc-helpers.php
+++ b/includes/class-gtm-server-side-wc-helpers.php
@@ -411,6 +411,15 @@ class GTM_Server_Side_WC_Helpers {
 	}
 
 	/**
+	 * Check if user data can be output (considering cache protection).
+	 *
+	 * @return bool
+	 */
+	public function should_output_user_data() {
+		return $this->is_enable_user_data() && GTM_Server_Side_Helpers::can_output_sensitive_data();
+	}
+
+	/**
 	 * Return formatted price
 	 *
 	 * @param  mixed $price Price.


### PR DESCRIPTION
Use the gtm_server_side_is_page_cached filter (provided by the user) to determine whether it’s safe to output dynamic or sensitive data.

As an additional safeguard, we insert an HTML comment '<!-- DO NOT CACHE -->' whenever such data is output. This comment can be used to scan for potential data leaks in cached content.

At a minimum, users can include a check for this comment in their monitoring systems and trigger an alert or failure if it’s detected on a page that should be cached, such as the homepage.
