### PR TITLE
v.2.2.0: Dynamic data layer fields

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Tested up to:** 7.0.0
 
-**Stable tag:** 2.1.48
+**Stable tag:** 2.2.0
 
 **License:** GPLv2 or later
 
@@ -27,6 +27,7 @@ The **GTM Server Side** plugin by [stape.io](https://stape.io) is the easiest wa
 - Adds e-commerce Data Layer events.
 - Adds user data to Data Layer events.
 - Sends webhooks.
+- Provides the possibility to manage dynamic generation of data layer fields.
 
 ### Benefits
 
@@ -84,6 +85,9 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.2.0
+- Introduction of Dynamic Data Layer configuration.
 
 ## 2.1.48
 - Fixed purchase event.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
 Tested up to: 7.0.0
-Stable tag: 2.1.48
+Stable tag: 2.2.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -23,6 +23,7 @@ GTM Server Side plugin by stape.io features:
 * Adds e-commerce Data Layer events.
 * Adds user data to Data Layer events.
 * Sends webhooks.
+* Provides the possibility to manage dynamic generation of data layer fields.
 
 Benefits of GTM Server Side plugin by stape.io:
 
@@ -66,6 +67,9 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.2.0 =
+* Introduction of Dynamic Data Layer configuration.
 
 = 2.1.48 =
 * Fixed purchase event.

--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -1,4 +1,4 @@
-#gtm-server-side-admin-settings form h2 {
+#gtm-server-side-admin-settings form h2:not(.hndle) {
 	display: none;
 }
 
@@ -52,4 +52,145 @@
 #gtm-server-side-admin-settings:has( #gtm_server_side_placement-disable:checked ) .gtm-server-side-gtm-exclude-roles {
 	opacity: 0.4;
 	pointer-events: none;
+}
+
+/* ── Advanced parameters postbox ───────────────────────────────────────── */
+
+#gtm-adv-params {
+	margin-top: 16px;
+}
+
+#gtm-adv-params .hndle {
+	cursor: pointer;
+}
+
+#gtm-adv-params .inside {
+	padding: 12px 16px 16px;
+}
+
+.gtm-adv-section {
+	position: relative;
+	padding: 12px 0;
+}
+
+.gtm-adv-section::after {
+	content: '';
+	position: absolute;
+	left: -100vw;
+	width: 200vw;
+	bottom: -3px;
+	height: 1px;
+	background: #e5e5e5;
+}
+
+.gtm-adv-section h3 {
+	margin: 0 0 10px;
+	font-size: 13px;
+}
+
+.gtm-adv-field-row {
+	display: flex;
+	align-items: flex-start;
+	gap: 8px;
+	margin-bottom: 8px;
+}
+
+.gtm-adv-field-row > label {
+	min-width: 90px;
+	padding-top: 4px;
+	font-weight: 600;
+	color: #3c434a;
+}
+
+.gtm-data-points-container {
+	display: flex;
+	flex-direction: column;
+	gap: 6px;
+}
+
+.gtm-data-point-row {
+	display: flex;
+	align-items: center;
+	gap: 6px;
+}
+
+.gtm-remove-point.button-link {
+	color: #a00;
+	text-decoration: none;
+	font-size: 18px;
+	line-height: 1;
+	padding: 0 4px;
+	cursor: pointer;
+}
+
+.gtm-remove-point.button-link:hover {
+	color: #dc3232;
+}
+
+.gtm-remove-point.button-link.is-hidden {
+	display: none;
+}
+
+.gtm-add-data-point {
+	margin-top: 0;
+	width: 80px;
+}
+
+.gtm-prefix-input {
+	width: 100px;
+}
+
+.gtm-separator-input {
+	width: 70px;
+}
+
+.gtm-meta-key {
+	display: none;
+}
+
+.gtm-meta-key.is-visible {
+	display: inline-block;
+}
+
+.gtm-separator-row.is-hidden {
+	display: none;
+}
+
+.gtm-result-preview {
+	display: inline-block;
+	padding: 2px 8px;
+	background: #d1e7dd;
+	border: 1px solid #badbcc;
+	border-radius: 3px;
+	font-family: monospace;
+	font-size: 12px;
+	color: #0f5132;
+}
+
+.gtm-adv-grid {
+	display: grid;
+	grid-template-columns: repeat(2, min-content);
+	gap: 16px;
+	overflow: hidden;
+	border-bottom: 1px solid #e5e5e5;
+}
+
+#gtm-adv-params h3 > code {
+	display: inline-block;
+	padding: 2px 8px;
+	background: #cfe2ff;
+	border: 1px solid #b6d4fe;
+	border-radius: 3px;
+	font-size: 14px;
+	color: #084298;
+	font-weight: 400;
+}
+
+.gtm-adv-reset-row {
+	padding-top: 12px;
+	margin-top: 4px;
+}
+
+.gtm-adv-note {
+	margin: 0 0 12px;
 }

--- a/assets/js/admin-javascript.js
+++ b/assets/js/admin-javascript.js
@@ -7,7 +7,7 @@
 jQuery( document ).ready(
 	function () {
 		// Validate.
-		var formGtmServerSide = jQuery( '.js-form-gtm-server-side' ).validate(
+		const formGtmServerSide = jQuery( '.js-form-gtm-server-side' ).validate(
 			{
 				rules: {
 					gtm_server_side_web_container_id: {
@@ -63,10 +63,10 @@ jQuery( document ).ready(
 					return true;
 				}
 
-				var isPurchaseChecked   = jQuery( '#gtm_server_side_webhooks_purchase' ).is( ':checked' );
-				var isProcessingChecked = jQuery( '#gtm_server_side_webhooks_processing' ).is( ':checked' );
-				var isCompletedChecked  = jQuery( '#gtm_server_side_webhooks_completed' ).is( ':checked' );
-				var isRefundChecked     = jQuery( '#gtm_server_side_webhooks_refund' ).is( ':checked' );
+				const isPurchaseChecked   = jQuery( '#gtm_server_side_webhooks_purchase' ).is( ':checked' );
+				const isProcessingChecked = jQuery( '#gtm_server_side_webhooks_processing' ).is( ':checked' );
+				const isCompletedChecked  = jQuery( '#gtm_server_side_webhooks_completed' ).is( ':checked' );
+				const isRefundChecked     = jQuery( '#gtm_server_side_webhooks_refund' ).is( ':checked' );
 
 				return isPurchaseChecked || isProcessingChecked || isCompletedChecked || isRefundChecked;
 			},
@@ -116,6 +116,116 @@ jQuery( document ).ready(
 				pluginGtmServerSide.initTabDataLayer();
 			}
 		);
+
+		// Advanced parameters — activate native WP postbox toggle.
+		const $advParams = jQuery( '#gtm-adv-params' );
+		if ( $advParams.length ) {
+			if ( typeof postboxes !== 'undefined' ) {
+				postboxes.add_postbox_toggles( pagenow );
+				const $sortable = jQuery( '#normal-sortables' );
+				if ( $sortable.sortable( 'instance' ) ) {
+					$sortable.sortable(
+						'option',
+						'cancel',
+						$sortable.sortable( 'option', 'cancel' ) + ', #gtm-adv-params'
+					);
+				}
+			}
+
+			// Meta key reveal on type change.
+			$advParams.on( 'change', '.gtm-point-type-select', function () {
+				const $row = jQuery( this ).closest( '.gtm-data-point-row' );
+				$row.find( '.gtm-meta-key' ).toggleClass( 'is-visible', 'custom' === jQuery( this ).val() );
+				pluginGtmServerSide.updateAdvPreview( jQuery( this ).closest( '.gtm-adv-section' ) );
+			} );
+
+			// Add data point.
+			$advParams.on( 'click', '.gtm-add-data-point', function () {
+				const $section   = jQuery( this ).closest( '.gtm-adv-section' );
+				const $container = $section.find( '.gtm-data-points-container' );
+				const $rows      = $container.find( '.gtm-data-point-row' );
+				const limit      = $section.data( 'points-limit' );
+				const newIndex   = $rows.length;
+				const $addBtn    = $container.find( '.gtm-add-data-point' ).detach();
+				const $clone     = $rows.last().clone();
+
+				$clone.find( '[name]' ).each( function () {
+					jQuery( this ).attr( 'name', jQuery( this ).attr( 'name' ).replace(
+						/\[points\]\[\d+\]/,
+						'[points][' + newIndex + ']'
+					) );
+				} );
+				$clone.find( 'select' ).prop( 'selectedIndex', 0 );
+				$clone.find( 'input[type=text]' ).val( '' );
+				$clone.find( '.gtm-meta-key' ).removeClass( 'is-visible' );
+				$container.append( $clone ).append( $addBtn );
+
+				$section.find( '.gtm-add-data-point' ).prop( 'disabled', $container.find( '.gtm-data-point-row' ).length >= limit );
+				$container.find( '.gtm-remove-point' ).removeClass( 'is-hidden' );
+				$section.find( '.gtm-separator-row' ).removeClass( 'is-hidden' );
+				pluginGtmServerSide.updateAdvPreview( $section );
+			} );
+
+			// Remove data point.
+			$advParams.on( 'click', '.gtm-remove-point', function () {
+				const $section   = jQuery( this ).closest( '.gtm-adv-section' );
+				const $container = $section.find( '.gtm-data-points-container' );
+				if ( $container.find( '.gtm-data-point-row' ).length <= 1 ) {
+					return;
+				}
+				jQuery( this ).closest( '.gtm-data-point-row' ).remove();
+				$container.find( '.gtm-data-point-row' ).each( function ( i ) {
+					jQuery( this ).find( '[name]' ).each( function () {
+						jQuery( this ).attr( 'name', jQuery( this ).attr( 'name' ).replace(
+							/\[points\]\[\d+\]/,
+							'[points][' + i + ']'
+						) );
+					} );
+				} );
+				$section.find( '.gtm-add-data-point' ).prop( 'disabled', false );
+				if ( $container.find( '.gtm-data-point-row' ).length === 1 ) {
+					$container.find( '.gtm-remove-point' ).addClass( 'is-hidden' );
+					$section.find( '.gtm-separator-row' ).addClass( 'is-hidden' );
+				}
+				pluginGtmServerSide.updateAdvPreview( $section );
+			} );
+
+			// Live preview on prefix / separator change.
+			$advParams.on( 'input', '.gtm-prefix-input, .gtm-separator-input', function () {
+				pluginGtmServerSide.updateAdvPreview( jQuery( this ).closest( '.gtm-adv-section' ) );
+			} );
+
+			// Reset to defaults.
+			$advParams.on( 'click', '.gtm-reset-to-defaults', function () {
+				$advParams.find( '.gtm-adv-section' ).each( function () {
+					const $section    = jQuery( this );
+					const $container  = $section.find( '.gtm-data-points-container' );
+					const defaultType = $section.data( 'default-point' );
+
+					$container.find( '.gtm-data-point-row' ).not( ':first' ).remove();
+					const $firstRow = $container.find( '.gtm-data-point-row' );
+					$firstRow.find( '.gtm-point-type-select' ).val( defaultType );
+					$firstRow.find( '.gtm-meta-key' ).val( '' ).removeClass( 'is-visible' );
+					$firstRow.find( '.gtm-remove-point' ).addClass( 'is-hidden' );
+
+					$section.find( '.gtm-prefix-input' ).val( '' );
+					$section.find( '.gtm-separator-input' ).val( '' );
+					$section.find( '.gtm-separator-row' ).addClass( 'is-hidden' );
+					$section.find( '.gtm-add-data-point' ).prop( 'disabled', false );
+
+					pluginGtmServerSide.updateAdvPreview( $section );
+				} );
+			} );
+
+			// Initial state.
+			$advParams.find( '.gtm-adv-section' ).each( function () {
+				const $section   = jQuery( this );
+				const $container = $section.find( '.gtm-data-points-container' );
+				const limit      = $section.data( 'points-limit' );
+				$section.find( '.gtm-add-data-point' ).prop( 'disabled', $container.find( '.gtm-data-point-row' ).length >= limit );
+				pluginGtmServerSide.updateAdvPreview( $section );
+			} );
+		}
 		// ----------
 
 		// Tab "Webhooks".
@@ -132,7 +242,7 @@ jQuery( document ).ready(
 				e.preventDefault();
 
 				formGtmServerSide.element( "#gtm_server_side_webhooks_container_url" );
-				var $elMessage = jQuery( '.js-ajax-message' );
+				const $elMessage = jQuery( '.js-ajax-message' );
 				$elMessage.html( '<i>' + $elMessage.data( 'message-loading' ) + '</i>' );
 
 				jQuery.post(
@@ -160,8 +270,8 @@ jQuery( document ).ready(
 			pluginGtmServerSide.initTabCustomerMatch
 		);
 
-		let $backfill         = jQuery( '#gtm_server_side_field_cust_match_backfill' );
-		let isBackfillChecked = $backfill.is( ':checked' );
+		const $backfill         = jQuery( '#gtm_server_side_field_cust_match_backfill' );
+		const isBackfillChecked = $backfill.is( ':checked' );
 		$backfill.on(
 			'click',
 			function() {
@@ -180,7 +290,7 @@ jQuery( document ).ready(
 			}
 		);
 
-		let idsForSubmitEnabled = [
+		const idsForSubmitEnabled = [
 			'#gtm_server_side_field_cust_match_container_api_key',
 			'#gtm_server_side_field_cust_match_gads_oper_cust_id',
 			'#gtm_server_side_field_cust_match_gads_login_cust_id',
@@ -200,9 +310,9 @@ jQuery( document ).ready(
 	}
 );
 
-var pluginGtmServerSide = {
+const pluginGtmServerSide = {
 	initTabDataLayer: function() {
-		var $elUserData = jQuery( '#gtm_server_side_data_layer_user_data' );
+		const $elUserData = jQuery( '#gtm_server_side_data_layer_user_data' );
 		if ( false === jQuery( '#gtm_server_side_data_layer_ecommerce' ).is( ':checked' ) ) {
 			$elUserData
 				.prop( 'checked', false )
@@ -213,10 +323,10 @@ var pluginGtmServerSide = {
 	},
 
 	initTabWebhooks: function() {
-		var $elContainerUrl = jQuery( '#gtm_server_side_webhooks_container_url' );
-		var $elPurchase     = jQuery( '#gtm_server_side_webhooks_purchase' );
-		var $elRefund       = jQuery( '#gtm_server_side_webhooks_refund' );
-		var $btnTest        = jQuery( '.js-send-test-webhooks' );
+		const $elContainerUrl = jQuery( '#gtm_server_side_webhooks_container_url' );
+		const $elPurchase     = jQuery( '#gtm_server_side_webhooks_purchase' );
+		const $elRefund       = jQuery( '#gtm_server_side_webhooks_refund' );
+		const $btnTest        = jQuery( '.js-send-test-webhooks' );
 
 		if ( false === jQuery( '#gtm_server_side_webhooks_enable' ).is( ':checked' ) ) {
 			$elContainerUrl.prop( 'disabled', true );
@@ -234,9 +344,9 @@ var pluginGtmServerSide = {
 	},
 
 	initTabCustomerMatch: function() {
-		let isShareEmailChecked = jQuery( '#gtm_server_side_field_cust_match_user_share_email' ).is( ':checked' );
-		let isSharePhoneChecked = jQuery( '#gtm_server_side_field_cust_match_user_share_phone' ).is( ':checked' );
-		let $shareAddress       = jQuery( '#gtm_server_side_field_cust_match_user_share_address' );
+		const isShareEmailChecked = jQuery( '#gtm_server_side_field_cust_match_user_share_email' ).is( ':checked' );
+		const isSharePhoneChecked = jQuery( '#gtm_server_side_field_cust_match_user_share_phone' ).is( ':checked' );
+		const $shareAddress       = jQuery( '#gtm_server_side_field_cust_match_user_share_address' );
 
 		if ( isShareEmailChecked && isSharePhoneChecked ) {
 			$shareAddress.prop( 'disabled', false );
@@ -248,8 +358,8 @@ var pluginGtmServerSide = {
 	},
 
 	changeContainerId: function() {
-		var val   = jQuery( '.js-gtm_server_side_placement:checked' ).val();
-		var $elCI = jQuery( '#gtm_server_side_web_container_id' );
+		const val   = jQuery( '.js-gtm_server_side_placement:checked' ).val();
+		const $elCI = jQuery( '#gtm_server_side_web_container_id' );
 
 		if ( [ 'code', 'plugin' ].includes( val ) ) {
 			$elCI.rules(
@@ -264,8 +374,8 @@ var pluginGtmServerSide = {
 	},
 
 	changeExcludeGtmUserRoles: function() {
-		let $elRole = jQuery( '.js-gtm_server_side_gtm_exclude_roles' );
-		let $block  = jQuery( '.js-gtm-server-side-gtm-exclude-roles-block' );
+		const $elRole = jQuery( '.js-gtm_server_side_gtm_exclude_roles' );
+		const $block  = jQuery( '.js-gtm-server-side-gtm-exclude-roles-block' );
 
 		if ( $elRole.is( ':checked' ) ) {
 			$block.show();
@@ -275,7 +385,7 @@ var pluginGtmServerSide = {
 	},
 
 	changeWebIdentifier: function() {
-		var $elWebIdentifier = jQuery( '#gtm_server_side_web_identifier' );
+		const $elWebIdentifier = jQuery( '#gtm_server_side_web_identifier' );
 		if ( 0 === $elWebIdentifier.length ) {
 			return;
 		}
@@ -294,12 +404,12 @@ var pluginGtmServerSide = {
 	},
 
 	changeFieldPlacement: function() {
-		var $placementPlugin = jQuery( 'input[type=hidden]#gtm_server_side_placement-plugin' );
+		const $placementPlugin = jQuery( 'input[type=hidden]#gtm_server_side_placement-plugin' );
 		if ( ! $placementPlugin.length ) {
 			return;
 		}
 
-		var name = 'gtm_server_side_placement';
+		const name = 'gtm_server_side_placement';
 		$placementPlugin.attr( 'name', name + '-tmp' );
 
 		jQuery( '.js-gtm_server_side_placement' ).each(
@@ -310,7 +420,7 @@ var pluginGtmServerSide = {
 	},
 
 	validateContainerIdByPlacementPlugin: function() {
-		var $placementPlugin = jQuery( 'input[type=hidden]#gtm_server_side_placement-plugin' );
+		const $placementPlugin = jQuery( 'input[type=hidden]#gtm_server_side_placement-plugin' );
 		if ( ! $placementPlugin.length ) {
 			return;
 		}
@@ -323,5 +433,39 @@ var pluginGtmServerSide = {
 				}
 			);
 		}
+	},
+
+	/**
+	 * Recompute and display the Result preview for a builder or source section.
+	 *
+	 * @param {jQuery} $section The .gtm-adv-section element.
+	 */
+	updateAdvPreview: function( $section ) {
+		const $preview = $section.find( '.gtm-result-preview' );
+		if ( ! $preview.length ) {
+			return;
+		}
+
+		const exampleValues = {
+			product_id:   '1530',
+			variation_id: '1602',
+			sku:          'C33S020636',
+			gtin:         '12345678',
+			custom:       'customValue',
+		};
+
+		const prefix    = $section.find( '.gtm-prefix-input' ).val() || '';
+		const separator = $section.find( '.gtm-separator-input' ).val() || '';
+		const parts     = [];
+
+		$section.find( '.gtm-point-type-select' ).each( function() {
+			const type  = jQuery( this ).val();
+			const value = exampleValues[ type ] || '';
+			if ( value !== '' ) {
+				parts.push( value );
+			}
+		} );
+
+		$preview.text( prefix + parts.join( separator ) || '\u2014' );
 	},
 };

--- a/assets/js/admin-javascript.js
+++ b/assets/js/admin-javascript.js
@@ -130,6 +130,18 @@ jQuery( document ).ready(
 						$sortable.sortable( 'option', 'cancel' ) + ', #gtm-adv-params'
 					);
 				}
+
+				// Collapse by default once, then keep user-driven state.
+				if ( typeof getUserSetting === 'function' && typeof setUserSetting === 'function' ) {
+					const wasDefaultApplied = getUserSetting( 'gtm_adv_params_default_closed' );
+					if ( ! wasDefaultApplied ) {
+						$advParams.addClass( 'closed' );
+						postboxes.save_state( pagenow );
+						setUserSetting( 'gtm_adv_params_default_closed', '1' );
+					}
+				} else {
+					$advParams.addClass( 'closed' );
+				}
 			}
 
 			// Meta key reveal on type change.

--- a/assets/js/admin-javascript.js
+++ b/assets/js/admin-javascript.js
@@ -447,8 +447,8 @@ const pluginGtmServerSide = {
 		}
 
 		const exampleValues = {
-			product_id:   '1530',
-			variation_id: '1602',
+			parent_id:    '1530',
+			product_id:   '1602',
 			sku:          'C33S020636',
 			gtin:         '12345678',
 			custom:       'customValue',

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -19,6 +19,7 @@ define( 'GTM_SERVER_SIDE_COOKIE_KEEPER_NAME', '_sbp' );
 define( 'GTM_SERVER_SIDE_DATA_LAYER_CUSTOM_EVENT_NAME', '_stape' );
 
 define( 'GTM_SERVER_SIDE_FIELD_VERSION', 'gtm_server_side_version' );
+define( 'GTM_SERVER_SIDE_TRANSLATION_DOMAIN', 'gtm-server-side' );
 
 // Tab: General.
 define( 'GTM_SERVER_SIDE_FIELD_PLACEMENT', 'gtm_server_side_placement' );
@@ -78,6 +79,9 @@ define( 'GTM_SERVER_SIDE_CUST_MATCH_BACKFILL_FINISHED', 'gtm_server_side_cust_ma
 
 // d20260118.
 define( 'GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API', 'gtm_server_side_gtm_custom_loader_from_api' );
+
+// Tab: Data Layer — Advanced parameters.
+define( 'GTM_SERVER_SIDE_FIELD_ADV', 'gtm_server_side_adv' );
 
 
 // Autoload plugin classes.

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.1.48
+ * Version:           2.2.0
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+

--- a/includes/class-gtm-server-side-admin-settings-data-layer.php
+++ b/includes/class-gtm-server-side-admin-settings-data-layer.php
@@ -108,7 +108,7 @@ class GTM_Server_Side_Admin_Settings_Data_Layer {
 		wp_enqueue_script( 'postbox' );
 		add_meta_box(
 			'gtm-adv-params',
-			__( 'Advanced parameters', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ),
+			__( 'Field mapping', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ),
 			[ GTM_Server_Side_Advanced_Params::instance(), 'render_metabox' ],
 			'settings_page_' . GTM_SERVER_SIDE_ADMIN_SLUG,
 			'normal',

--- a/includes/class-gtm-server-side-admin-settings-data-layer.php
+++ b/includes/class-gtm-server-side-admin-settings-data-layer.php
@@ -108,7 +108,7 @@ class GTM_Server_Side_Admin_Settings_Data_Layer {
 		wp_enqueue_script( 'postbox' );
 		add_meta_box(
 			'gtm-adv-params',
-			__( 'Field mapping', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ),
+			__( 'Advanced Data Layer settings', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ),
 			[ GTM_Server_Side_Advanced_Params::instance(), 'render_metabox' ],
 			'settings_page_' . GTM_SERVER_SIDE_ADMIN_SLUG,
 			'normal',

--- a/includes/class-gtm-server-side-admin-settings-data-layer.php
+++ b/includes/class-gtm-server-side-admin-settings-data-layer.php
@@ -97,5 +97,22 @@ class GTM_Server_Side_Admin_Settings_Data_Layer {
 			GTM_SERVER_SIDE_ADMIN_SLUG,
 			GTM_SERVER_SIDE_ADMIN_GROUP_DATA_LAYER
 		);
+
+		// Advanced parameters — single combined option.
+		register_setting(
+			GTM_SERVER_SIDE_ADMIN_GROUP,
+			GTM_SERVER_SIDE_FIELD_ADV,
+			[ 'sanitize_callback' => [ 'GTM_Server_Side_Advanced_Params', 'sanitize' ] ]
+		);
+
+		wp_enqueue_script( 'postbox' );
+		add_meta_box(
+			'gtm-adv-params',
+			__( 'Advanced parameters', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ),
+			[ GTM_Server_Side_Advanced_Params::instance(), 'render_metabox' ],
+			'settings_page_' . GTM_SERVER_SIDE_ADMIN_SLUG,
+			'normal',
+			'default'
+		);
 	}
 }

--- a/includes/class-gtm-server-side-advanced-params.php
+++ b/includes/class-gtm-server-side-advanced-params.php
@@ -1,0 +1,519 @@
+<?php
+/**
+ * Advanced Data Layer parameters.
+ *
+ * @package    GTM_Server_Side
+ * @subpackage GTM_Server_Side/includes
+ * @since      2.1.47
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Advanced Data Layer parameters.
+ */
+class GTM_Server_Side_Advanced_Params {
+	use GTM_Server_Side_Singleton;
+
+	const ITEM_ID        = 'item_id';
+	const ITEM_SKU       = 'item_sku';
+	const ITEM_BRAND     = 'item_brand';
+	const TRANSACTION_ID = 'transaction_id';
+
+	private const POINT_TYPE_NONE         = 'none';
+	private const POINT_TYPE_PRODUCT_ID   = 'product_id';
+	private const POINT_TYPE_VARIATION_ID = 'variation_id';
+	private const POINT_TYPE_SKU          = 'sku';
+	private const POINT_TYPE_GTIN         = 'gtin';
+	private const POINT_TYPE_ORDER_NUMBER = 'order_number';
+	private const POINT_TYPE_ORDER_ID     = 'order_id';
+	private const POINT_TYPE_CUSTOM       = 'custom';
+
+	/**
+	 * @var array<string,mixed>|null
+	 */
+	private $advanced_params = null;
+
+	/**
+	 * @var array<string,string>|null
+	 */
+	private $brand_taxonomies = null;
+
+	/**
+	 * @var array<string,mixed>|null
+	 */
+	private $fields_config = null;
+
+	/**
+	 * @var array<string,mixed>|null
+	 */
+	private $labels = null;
+
+	/**
+	 * Sanitize callback.
+	 *
+	 * @param  mixed $input Raw form input array.
+	 * @return string JSON-encoded combined config, or empty string on bad input.
+	 */
+	public static function sanitize( $input ) {
+		if ( ! is_array( $input ) ) {
+			return '';
+		}
+		
+		$result = [];
+		
+		foreach ( self::instance()->get_fields_config() as $key => $field_config ) {
+			$result[ $key ] = self::sanitize_field( isset( $input[ $key ] ) ? $input[ $key ] : null, $field_config );
+		}
+
+		return wp_json_encode( $result );
+	}
+
+	/**
+	 * Get one advanced-parameter sub-config by key.
+	 *
+	 * @param  string $key Sub-key constant (e.g. self::ITEM_ID).
+	 * @return array
+	 */
+	public function get_config_value( $key ) {
+		if ( null === $this->advanced_params ) {
+			$raw = GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_ADV, '' );
+			$this->advanced_params = ! empty( $raw ) ? json_decode( $raw, true ) : [];
+
+			if ( ! is_array( $this->advanced_params ) ) {
+				$this->advanced_params = [];
+			}
+		}
+
+		return isset( $this->advanced_params[ $key ] ) ? $this->advanced_params[ $key ] : [];
+	}
+
+	/**
+	 * Resolve item_id for a product using the advanced settings.
+	 *
+	 * @param  WC_Product $product Product.
+	 * @return string
+	 */
+	public function resolve_item_id( $product ) {
+		$config = $this->get_config_value( self::ITEM_ID );
+		if ( empty( $config ) ) {
+			return (string) $product->get_id();
+		}
+
+		$parts = [];
+		foreach ( $config['points'] as $point ) {
+			$value = $this->resolve_product_point( $product, $point );
+			if ( '' !== $value ) {
+				$parts[] = $value;
+			}
+		}
+
+		$separator = isset( $config['separator'] ) ? $config['separator'] : '';
+		$prefix    = isset( $config['prefix'] ) ? $config['prefix'] : '';
+		$result    = $prefix . implode( $separator, $parts );
+
+		return '' !== $result ? $result : (string) $product->get_id();
+	}
+
+	/**
+	 * Resolve item_sku for a product using the advanced settings.
+	 *
+	 * @param  WC_Product $product Product.
+	 * @return string
+	 */
+	public function resolve_item_sku( $product ) {
+		$config = $this->get_config_value( self::ITEM_SKU );
+		if ( empty( $config ) ) {
+			return (string) $product->get_sku();
+		}
+
+		$parts = [];
+		foreach ( $config['points'] as $point ) {
+			$value = $this->resolve_product_point( $product, $point );
+			if ( '' !== $value ) {
+				$parts[] = $value;
+			}
+		}
+
+		$separator = isset( $config['separator'] ) ? $config['separator'] : '';
+		$prefix    = isset( $config['prefix'] ) ? $config['prefix'] : '';
+
+		return $prefix . implode( $separator, $parts );
+	}
+
+	/**
+	 * Resolve item_brand for a product using the advanced settings.
+	 * The filter takes priority over the UI setting.
+	 *
+	 * @param  int $product_id Product id.
+	 * @return string
+	 */
+	public function resolve_item_brand( $product_id ) {
+		$config = $this->get_config_value( self::ITEM_BRAND );
+		$points = isset( $config['points'] ) ? $config['points'] : [];
+		$point  = isset( $points[0] ) ? $points[0] : [ 'type' => self::POINT_TYPE_NONE ];
+		$type   = isset( $point['type'] ) ? $point['type'] : self::POINT_TYPE_NONE;
+
+		if ( self::POINT_TYPE_NONE === $type ) {
+			return '';
+		}
+
+		if ( self::POINT_TYPE_CUSTOM === $type ) {
+			$meta_key = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
+			return '' !== $meta_key ? (string) get_post_meta( $product_id, $meta_key, true ) : '';
+		}
+
+		return $this->get_brand_from_taxonomy( $product_id, $type );
+	}
+
+	/**
+	 * Resolve transaction_id for an order using the advanced settings.
+	 *
+	 * @param  WC_Order $order Order.
+	 * @return string
+	 */
+	public function resolve_transaction_id( $order ) {
+		$config = $this->get_config_value( self::TRANSACTION_ID );
+		$points = isset( $config['points'] ) ? $config['points'] : [];
+		$point  = isset( $points[0] ) ? $points[0] : [ 'type' => self::POINT_TYPE_ORDER_NUMBER ];
+		$type   = isset( $point['type'] ) ? $point['type'] : self::POINT_TYPE_ORDER_NUMBER;
+
+		if ( self::POINT_TYPE_ORDER_ID === $type ) {
+			return (string) $order->get_id();
+		}
+
+		if ( self::POINT_TYPE_CUSTOM === $type ) {
+			$meta_key = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
+			return '' !== $meta_key ? (string) get_post_meta( $order->get_id(), $meta_key, true ) : '';
+		}
+
+		return $order->get_order_number();
+	}
+
+	/**
+	 * Resolve one product data point (shared by item_id and item_sku).
+	 *
+	 * @param  WC_Product $product Product.
+	 * @param  array      $point   Data point config.
+	 * @return string
+	 */
+	private function resolve_product_point( $product, array $point ) {
+		$type = isset( $point['type'] ) ? $point['type'] : '';
+
+		switch ( $type ) {
+			case self::POINT_TYPE_PRODUCT_ID:
+				if ( 'variation' === $product->get_type() ) {
+					return $product->get_parent_id() > 0 ? (string) $product->get_parent_id() : '';
+				}
+
+				return (string) $product->get_id();
+
+			case self::POINT_TYPE_VARIATION_ID:
+				return 'variation' === $product->get_type() ? (string) $product->get_id() : '';
+
+			case self::POINT_TYPE_SKU:
+				return (string) $product->get_sku();
+
+			case self::POINT_TYPE_GTIN:
+				return (string) $product->get_global_unique_id();
+
+			case self::POINT_TYPE_CUSTOM:
+				$meta_key = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
+
+				return '' !== $meta_key ? (string) get_post_meta( $product->get_id(), $meta_key, true ) : '';
+		}
+
+		return '';
+	}
+
+	/**
+	 * Render the "Advanced parameters" metabox content.
+	 *
+	 * @return void
+	 */
+	public function render_metabox() {
+		$fields_config = $this->get_fields_config();
+		?>
+		<p class="description gtm-adv-note">
+			<?php esc_html_e( 'Choose what feeds each parameter. Default match current behavior.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
+		</p>
+		<div class="gtm-adv-grid">
+		<?php
+		foreach ( $fields_config as $key => $field_config ) {
+			$config = $this->get_config_value( $key );
+			if ( empty( $config ) ) {
+				$config = isset( $field_config['default'] ) ? $field_config['default'] : [];
+			}
+			$this->render_section( $key, $config, $field_config );
+		}
+		?>
+		</div>
+		<div class="gtm-adv-reset-row">
+			<button type="button" class="button button-secondary gtm-reset-to-defaults">
+				<?php esc_html_e( 'Reset to defaults', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
+			</button>
+		</div>
+		<?php
+	}
+
+	/**
+	 * Universally sanitize a single field's raw input based on its config.
+	 *
+	 * @param  mixed $input        Raw form input.
+	 * @param  array $field_config Entry from get_fields_config().
+	 * @return array Validated config.
+	 */
+	private static function sanitize_field( $input, array $field_config ) {
+		$allowed_types  = $field_config['data_points'];
+		$points_limit   = $field_config['points_limit'];
+		$prefix_allowed = $field_config['prefix_allowed'];
+		$default        = $field_config['default'];
+
+		if ( ! is_array( $input ) ) {
+			return $default;
+		}
+
+		$points = [];
+		if ( ! empty( $input['points'] ) && is_array( $input['points'] ) ) {
+			foreach ( $input['points'] as $point ) {
+				if ( ! is_array( $point ) ) {
+					continue;
+				}
+				$type = sanitize_key( isset( $point['type'] ) ? $point['type'] : '' );
+				if ( ! in_array( $type, $allowed_types, true ) ) {
+					continue;
+				}
+				$entry = [ 'type' => $type ];
+				if ( self::POINT_TYPE_CUSTOM === $type ) {
+					$entry['meta_key'] = sanitize_text_field( isset( $point['meta_key'] ) ? $point['meta_key'] : '' );
+				}
+				$points[] = $entry;
+			}
+		}
+
+		$points = array_slice( $points, 0, $points_limit );
+
+		if ( empty( $points ) ) {
+			$points = $default['points'];
+		}
+
+		$result = [ 'points' => $points ];
+
+		if ( $prefix_allowed ) {
+			$result['prefix']    = sanitize_text_field( isset( $input['prefix'] ) ? $input['prefix'] : '' );
+			$result['separator'] = sanitize_text_field( isset( $input['separator'] ) ? $input['separator'] : '' );
+		}
+
+		return $result;
+	}
+
+	private function get_brand_taxonomies()
+	{
+		if ( null !== $this->brand_taxonomies ) {
+			return $this->brand_taxonomies;
+		}
+
+		$this->brand_taxonomies = [];
+		if ( function_exists( 'get_object_taxonomies' ) ) {
+			foreach ( get_object_taxonomies( 'product', 'objects' ) as $slug => $tax ) {
+				if ( false !== strpos( $slug, 'brand' ) ) {
+					$this->brand_taxonomies[ $slug ] = sprintf( '%s (%s)', $tax->label, $slug );
+				}
+			}
+		}
+
+		return $this->brand_taxonomies;
+	}
+
+	private function get_fields_config()
+	{
+		if ($this->fields_config !== null) {
+			return $this->fields_config;
+		}
+
+		$brand_taxonomies  = $this->get_brand_taxonomies();
+		$gtin_available = method_exists( 'WC_Product', 'get_global_unique_id' );
+		$id_sku_points  = array_values( array_filter( [
+			self::POINT_TYPE_PRODUCT_ID,
+			self::POINT_TYPE_VARIATION_ID,
+			// self::POINT_TYPE_PARENT_ID,
+			self::POINT_TYPE_SKU,
+			$gtin_available ? self::POINT_TYPE_GTIN : null,
+			self::POINT_TYPE_CUSTOM,
+		] ) );
+
+		$brand_points = array_merge( [ self::POINT_TYPE_NONE ] , array_keys( $brand_taxonomies ), [ self::POINT_TYPE_CUSTOM ] );
+
+		$this->fields_config = [
+			self::ITEM_ID        => [
+				'prefix_allowed' => true,
+				'data_points'    => $id_sku_points,
+				'points_limit'   => 3,
+				'default'        => ['prefix' => '', 'points' => [['type' => self::POINT_TYPE_PRODUCT_ID]], 'separator' => ''],
+			],
+			self::ITEM_SKU       => [
+				'prefix_allowed' => true,
+				'data_points'    => $id_sku_points,
+				'points_limit'   => 3,
+				'default'        => ['prefix' => '', 'points' => [['type' => self::POINT_TYPE_SKU]], 'separator' => ''],
+			],
+			self::ITEM_BRAND     => [
+				'prefix_allowed' => false,
+				'data_points'    => $brand_points,
+				'points_limit'   => 1,
+				'default'        => ['points' => [['type' => self::POINT_TYPE_NONE]]],
+			],
+			self::TRANSACTION_ID => [
+				'prefix_allowed' => false,
+				'data_points'    => [self::POINT_TYPE_ORDER_NUMBER, self::POINT_TYPE_ORDER_ID, self::POINT_TYPE_CUSTOM],
+				'points_limit'   => 1,
+				'default'        => ['points' => [['type' => self::POINT_TYPE_ORDER_NUMBER]]],
+			],
+		];
+
+		return $this->fields_config;
+	}
+
+	private function get_labels()
+	{
+		if ( null !== $this->labels ) {
+			return $this->labels;
+		}
+
+		$this->labels = array_merge(
+			[
+				self::POINT_TYPE_NONE           => 'None',
+				self::POINT_TYPE_PRODUCT_ID     => 'Product ID',
+				self::POINT_TYPE_VARIATION_ID   => 'Variation ID',
+				// self::POINT_TYPE_PARENT_ID      => 'Parent ID',
+				self::POINT_TYPE_SKU            => 'SKU',
+				self::POINT_TYPE_GTIN           => 'GTIN',
+				self::POINT_TYPE_ORDER_NUMBER   => 'Order Number',
+				self::POINT_TYPE_ORDER_ID       => 'Order ID',
+				self::POINT_TYPE_CUSTOM         => 'Custom field (meta)',
+			],
+			$this->get_brand_taxonomies()
+		);
+
+		return $this->labels;
+	}
+
+	/**
+	 * @param string $key
+	 * @return string
+	 */
+	private function get_label( $key ) {
+		$labels = $this->get_labels();
+
+		return isset( $labels[ $key ] ) ? $labels[ $key ] : $key;
+	}
+
+	/**
+	 * Render one advanced-parameter section.
+	 *
+	 * @param  string $key          Sub-key constant value (e.g. 'item_id').
+	 * @param  array  $config       Saved config for this parameter.
+	 * @param  array  $field_config Field definition from get_fields_config().
+	 * @return void
+	 */
+	private function render_section( $key, array $config, array $field_config ) {
+		$input_prefix   = GTM_SERVER_SIDE_FIELD_ADV . '[' . $key . ']';
+		$prefix_allowed = $field_config['prefix_allowed'];
+		$data_points    = $field_config['data_points'];
+		$points_limit   = $field_config['points_limit'];
+		$is_multi       = $points_limit > 1;
+
+		$first_point = (string) reset( $data_points );
+		$points      = isset( $config['points'] ) ? $config['points'] : [ [ 'type' => $first_point ] ];
+		$has_multi   = count( $points ) > 1;
+		$default_type = isset( $field_config['default']['points'][0]['type'] ) ? $field_config['default']['points'][0]['type'] : '';
+		?>
+		<h3><code><?php echo esc_html( $key ); ?></code></h3>
+		<div class="gtm-adv-section"
+			data-option="<?php echo esc_attr( $key ); ?>"
+			data-points-limit="<?php echo (int) $points_limit; ?>"
+			data-default-point="<?php echo esc_attr( $default_type ); ?>">
+			<div class="gtm-addv-field-rows">
+				<?php if ( $prefix_allowed ) : ?>
+				<div class="gtm-adv-field-row">
+					<label><?php esc_html_e( 'Prefix', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?></label>
+					<input type="text"
+						name="<?php echo esc_attr( $input_prefix ); ?>[prefix]"
+						value="<?php echo esc_attr( isset( $config['prefix'] ) ? $config['prefix'] : '' ); ?>"
+						class="gtm-prefix-input">
+				</div>
+				<?php endif; ?>
+				<div class="gtm-adv-field-row">
+					<label><?php esc_html_e( $is_multi ? 'Data points' : 'Source', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?></label>
+					<div class="gtm-data-points-container">
+						<?php foreach ( $points as $index => $point ) :
+							$type         = isset( $point['type'] ) ? $point['type'] : $first_point;
+							$meta_key_val = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
+						?>
+							<div class="gtm-data-point-row">
+								<select name="<?php echo esc_attr( $input_prefix ); ?>[points][<?php echo (int) $index; ?>][type]"
+									class="gtm-point-type-select">
+									<?php foreach ( $data_points as $val ) : ?>
+										<option value="<?php echo esc_attr( $val ); ?>" <?php selected( $type, $val ); ?>>
+											<?php echo esc_html( $this->get_label( $val ) ); ?>
+										</option>
+									<?php endforeach; ?>
+								</select>
+								<input type="text"
+									name="<?php echo esc_attr( $input_prefix ); ?>[points][<?php echo (int) $index; ?>][meta_key]"
+									value="<?php echo esc_attr( $meta_key_val ); ?>"
+									placeholder="<?php esc_attr_e( 'Meta key', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>"
+									class="gtm-meta-key<?php echo self::POINT_TYPE_CUSTOM === $type ? ' is-visible' : ''; ?>">
+								<?php if ( $is_multi ) : ?>
+									<button type="button" class="gtm-remove-point button-link<?php echo ! $has_multi ? ' is-hidden' : ''; ?>" aria-label="<?php esc_attr_e( 'Remove', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>">&times;</button>
+								<?php endif; ?>
+							</div>
+						<?php endforeach; ?>
+						<?php if ( $is_multi ) : ?>
+							<button type="button" class="gtm-add-data-point button button-secondary"<?php echo count( $points ) >= $points_limit ? ' disabled' : ''; ?>><?php esc_html_e( '+ Add', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?></button>
+						<?php endif; ?>
+					</div>
+				</div>
+				<?php if ( $is_multi ) : ?>
+				<div class="gtm-adv-field-row gtm-separator-row<?php echo $has_multi ? '' : ' is-hidden'; ?>">
+					<label><?php esc_html_e( 'Separator', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?></label>
+					<input type="text"
+						name="<?php echo esc_attr( $input_prefix ); ?>[separator]"
+						value="<?php echo esc_attr( isset( $config['separator'] ) ? $config['separator'] : '' ); ?>"
+						class="gtm-separator-input"
+						size="5">
+				</div>
+				<div class="gtm-adv-field-row">
+					<label><?php esc_html_e( 'Result', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?></label>
+					<code class="gtm-result-preview"></code>
+				</div>
+				<?php endif; ?>
+			</div>
+		</div>
+		<?php
+	}	
+
+	/**
+	 * Look up the first term name for a product in a given taxonomy.
+	 *
+	 * @param  int    $product_id Product id.
+	 * @param  string $taxonomy   Taxonomy slug.
+	 * @return string
+	 */
+	private function get_brand_from_taxonomy( $product_id, $taxonomy ) {
+		$terms = wp_get_post_terms(
+			$product_id,
+			$taxonomy,
+			[
+				'orderby' => 'parent',
+				'order'   => 'ASC',
+			]
+		);
+
+		if ( empty( $terms ) || ! is_a( $terms[0], 'WP_Term' ) ) {
+			return '';
+		}
+
+		return $terms[0]->slug;
+	}
+}

--- a/includes/class-gtm-server-side-advanced-params.php
+++ b/includes/class-gtm-server-side-advanced-params.php
@@ -100,8 +100,9 @@ class GTM_Server_Side_Advanced_Params {
 			return (string) $product->get_id();
 		}
 
-		$parts = [];
-		foreach ( $config['points'] as $point ) {
+		$parts  = [];
+		$points = isset( $config['points'] ) && is_array( $config['points'] ) ? $config['points'] : [];
+		foreach ( $points as $point ) {
 			$value = $this->resolve_product_point( $product, $point );
 			if ( '' !== $value ) {
 				$parts[] = $value;
@@ -127,8 +128,9 @@ class GTM_Server_Side_Advanced_Params {
 			return (string) $product->get_sku();
 		}
 
-		$parts = [];
-		foreach ( $config['points'] as $point ) {
+		$parts  = [];
+		$points = isset( $config['points'] ) && is_array( $config['points'] ) ? $config['points'] : [];
+		foreach ( $points as $point ) {
 			$value = $this->resolve_product_point( $product, $point );
 			if ( '' !== $value ) {
 				$parts[] = $value;

--- a/includes/class-gtm-server-side-advanced-params.php
+++ b/includes/class-gtm-server-side-advanced-params.php
@@ -232,9 +232,7 @@ class GTM_Server_Side_Advanced_Params {
 		$fields_config = $this->get_fields_config();
 		?>
 		<p class="description gtm-adv-note">
-			<?php esc_html_e( 'Choose what value goes into each field so it matches the key your ad catalog uses.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
-			<br>
-			<?php esc_html_e( 'Defaults match the current behaviour, nothing changes unless you edit a field.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
+			<?php esc_html_e( 'Choose what value goes into each field so it matches the key your ad catalog uses. Defaults match the current behaviour, nothing changes unless you edit a field. These settings apply to both your data layer and webhooks.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
 		</p>
 		<div class="gtm-adv-grid">
 		<?php

--- a/includes/class-gtm-server-side-advanced-params.php
+++ b/includes/class-gtm-server-side-advanced-params.php
@@ -22,7 +22,7 @@ class GTM_Server_Side_Advanced_Params {
 
 	private const POINT_TYPE_NONE         = 'none';
 	private const POINT_TYPE_PRODUCT_ID   = 'product_id';
-	private const POINT_TYPE_VARIATION_ID = 'variation_id';
+	private const POINT_TYPE_PARENT_ID    = 'parent_id';
 	private const POINT_TYPE_SKU          = 'sku';
 	private const POINT_TYPE_GTIN         = 'gtin';
 	private const POINT_TYPE_ORDER_NUMBER = 'order_number';
@@ -143,12 +143,11 @@ class GTM_Server_Side_Advanced_Params {
 
 	/**
 	 * Resolve item_brand for a product using the advanced settings.
-	 * The filter takes priority over the UI setting.
 	 *
-	 * @param  int $product_id Product id.
+	 * @param  WC_Product $product Product.
 	 * @return string
 	 */
-	public function resolve_item_brand( $product_id ) {
+	public function resolve_item_brand( $product ) {
 		$config = $this->get_config_value( self::ITEM_BRAND );
 		$points = isset( $config['points'] ) ? $config['points'] : [];
 		$point  = isset( $points[0] ) ? $points[0] : [ 'type' => self::POINT_TYPE_NONE ];
@@ -158,12 +157,14 @@ class GTM_Server_Side_Advanced_Params {
 			return '';
 		}
 
+		$lookup_id = 'variation' === $product->get_type() ? $product->get_parent_id() : $product->get_id();
+
 		if ( self::POINT_TYPE_CUSTOM === $type ) {
 			$meta_key = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
-			return '' !== $meta_key ? (string) get_post_meta( $product_id, $meta_key, true ) : '';
+			return '' !== $meta_key ? (string) get_post_meta( $lookup_id, $meta_key, true ) : '';
 		}
 
-		return $this->get_brand_from_taxonomy( $product_id, $type );
+		return $this->get_brand_from_taxonomy( $lookup_id, $type );
 	}
 
 	/**
@@ -184,7 +185,7 @@ class GTM_Server_Side_Advanced_Params {
 
 		if ( self::POINT_TYPE_CUSTOM === $type ) {
 			$meta_key = isset( $point['meta_key'] ) ? $point['meta_key'] : '';
-			return '' !== $meta_key ? (string) get_post_meta( $order->get_id(), $meta_key, true ) : '';
+			return '' !== $meta_key ? (string) $order->get_meta( $meta_key, true ) : '';
 		}
 
 		return $order->get_order_number();
@@ -202,14 +203,10 @@ class GTM_Server_Side_Advanced_Params {
 
 		switch ( $type ) {
 			case self::POINT_TYPE_PRODUCT_ID:
-				if ( 'variation' === $product->get_type() ) {
-					return $product->get_parent_id() > 0 ? (string) $product->get_parent_id() : '';
-				}
-
 				return (string) $product->get_id();
 
-			case self::POINT_TYPE_VARIATION_ID:
-				return 'variation' === $product->get_type() ? (string) $product->get_id() : '';
+			case self::POINT_TYPE_PARENT_ID:
+				return 'variation' === $product->get_type() ? (string) $product->get_parent_id() : '';
 
 			case self::POINT_TYPE_SKU:
 				return (string) $product->get_sku();
@@ -235,7 +232,9 @@ class GTM_Server_Side_Advanced_Params {
 		$fields_config = $this->get_fields_config();
 		?>
 		<p class="description gtm-adv-note">
-			<?php esc_html_e( 'Choose what feeds each parameter. Default match current behavior.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
+			<?php esc_html_e( 'Choose what value goes into each field so it matches the key your ad catalog uses.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
+			<br>
+			<?php esc_html_e( 'Defaults match the current behaviour, nothing changes unless you edit a field.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>
 		</p>
 		<div class="gtm-adv-grid">
 		<?php
@@ -335,8 +334,7 @@ class GTM_Server_Side_Advanced_Params {
 		$gtin_available = method_exists( 'WC_Product', 'get_global_unique_id' );
 		$id_sku_points  = array_values( array_filter( [
 			self::POINT_TYPE_PRODUCT_ID,
-			self::POINT_TYPE_VARIATION_ID,
-			// self::POINT_TYPE_PARENT_ID,
+			self::POINT_TYPE_PARENT_ID,
 			self::POINT_TYPE_SKU,
 			$gtin_available ? self::POINT_TYPE_GTIN : null,
 			self::POINT_TYPE_CUSTOM,
@@ -384,13 +382,12 @@ class GTM_Server_Side_Advanced_Params {
 			[
 				self::POINT_TYPE_NONE           => 'None',
 				self::POINT_TYPE_PRODUCT_ID     => 'Product ID',
-				self::POINT_TYPE_VARIATION_ID   => 'Variation ID',
-				// self::POINT_TYPE_PARENT_ID      => 'Parent ID',
+				self::POINT_TYPE_PARENT_ID      => 'Parent ID',
 				self::POINT_TYPE_SKU            => 'SKU',
 				self::POINT_TYPE_GTIN           => 'GTIN',
 				self::POINT_TYPE_ORDER_NUMBER   => 'Order Number',
 				self::POINT_TYPE_ORDER_ID       => 'Order ID',
-				self::POINT_TYPE_CUSTOM         => 'Custom field (meta)',
+				self::POINT_TYPE_CUSTOM         => 'Custom field',
 			],
 			$this->get_brand_taxonomies()
 		);
@@ -462,7 +459,7 @@ class GTM_Server_Side_Advanced_Params {
 								<input type="text"
 									name="<?php echo esc_attr( $input_prefix ); ?>[points][<?php echo (int) $index; ?>][meta_key]"
 									value="<?php echo esc_attr( $meta_key_val ); ?>"
-									placeholder="<?php esc_attr_e( 'Meta key', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>"
+									placeholder="<?php esc_attr_e( 'Custom field key', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>"
 									class="gtm-meta-key<?php echo self::POINT_TYPE_CUSTOM === $type ? ' is-visible' : ''; ?>">
 								<?php if ( $is_multi ) : ?>
 									<button type="button" class="gtm-remove-point button-link<?php echo ! $has_multi ? ' is-hidden' : ''; ?>" aria-label="<?php esc_attr_e( 'Remove', GTM_SERVER_SIDE_TRANSLATION_DOMAIN ); ?>">&times;</button>
@@ -514,6 +511,6 @@ class GTM_Server_Side_Advanced_Params {
 			return '';
 		}
 
-		return $terms[0]->slug;
+		return $terms[0]->name;
 	}
 }

--- a/includes/class-gtm-server-side-event-purchase.php
+++ b/includes/class-gtm-server-side-event-purchase.php
@@ -85,7 +85,7 @@ class GTM_Server_Side_Event_Purchase {
 			'event'          => GTM_Server_Side_Helpers::get_data_layer_event_name( 'purchase' ),
 			'ecomm_pagetype' => 'purchase',
 			'ecommerce'      => array(
-				'transaction_id'  => esc_attr( $order->get_order_number() ),
+				'transaction_id'  => esc_attr( GTM_Server_Side_Advanced_Params::instance()->resolve_transaction_id( $order ) ),
 				'affiliation'     => '',
 				'value'           => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'             => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),

--- a/includes/class-gtm-server-side-state-helpers.php
+++ b/includes/class-gtm-server-side-state-helpers.php
@@ -52,6 +52,7 @@ class GTM_Server_Side_State_Helpers {
 
 		$result = array();
 		$cart   = WC()->cart->get_cart();
+		$adv    = GTM_Server_Side_Advanced_Params::instance();
 		foreach ( $cart as $product_loop ) {
 			$product = $product_loop['data'];
 
@@ -61,8 +62,8 @@ class GTM_Server_Side_State_Helpers {
 
 			$product_data = array(
 				'item_variant'     => isset( $product_loop['variation_id'] ) && $product_loop['variation_id'] ? esc_attr( $product_loop['variation_id'] ) : '',
-				'item_id'          => esc_attr( $product->get_id() ),
-				'item_sku'         => esc_attr( $product->get_sku() ),
+				'item_id'          => esc_attr( $adv->resolve_item_id( $product ) ),
+				'item_sku'         => esc_attr( $adv->resolve_item_sku( $product ) ),
 				'item_name'        => esc_attr( $product->get_name() ),
 				'quantity'         => (int) $product_loop['quantity'],
 				'line_total_price' => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $product_loop['line_total'] ),
@@ -109,6 +110,7 @@ class GTM_Server_Side_State_Helpers {
 		}
 
 		$result = array();
+		$adv    = GTM_Server_Side_Advanced_Params::instance();
 		foreach ( $order->get_items() as $item ) {
 			if ( ! ( $item instanceof WC_Order_Item_Product ) ) {
 				continue;
@@ -123,8 +125,8 @@ class GTM_Server_Side_State_Helpers {
 
 			$product_data = array(
 				'item_variant'     => $variation_id ? esc_attr( $variation_id ) : '',
-				'item_id'          => esc_attr( $product->get_id() ),
-				'item_sku'         => esc_attr( $product->get_sku() ),
+				'item_id'          => esc_attr( $adv->resolve_item_id( $product ) ),
+				'item_sku'         => esc_attr( $adv->resolve_item_sku( $product ) ),
 				'item_name'        => esc_attr( $product->get_name() ),
 				'quantity'         => (int) $item->get_quantity(),
 				'line_total_price' => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $item->get_total() ),

--- a/includes/class-gtm-server-side-wc-helpers.php
+++ b/includes/class-gtm-server-side-wc-helpers.php
@@ -59,7 +59,7 @@ class GTM_Server_Side_WC_Helpers {
 		$advanced_parameters = GTM_Server_Side_Advanced_Params::instance();
 		$result = array(
 			'item_name'  => esc_attr( $product->get_name() ),
-			'item_brand' => esc_attr( $advanced_parameters->resolve_item_brand( $product->get_id() ) ),
+			'item_brand' => esc_attr( $advanced_parameters->resolve_item_brand( $product ) ),
 			'item_id'    => esc_attr( $advanced_parameters->resolve_item_id( $product ) ),
 			'item_sku'   => esc_attr( $advanced_parameters->resolve_item_sku( $product ) ),
 			'price'      => $this->formatted_price( $product->get_price() ),

--- a/includes/class-gtm-server-side-wc-helpers.php
+++ b/includes/class-gtm-server-side-wc-helpers.php
@@ -59,7 +59,7 @@ class GTM_Server_Side_WC_Helpers {
 		$advanced_parameters = GTM_Server_Side_Advanced_Params::instance();
 		$result = array(
 			'item_name'  => esc_attr( $product->get_name() ),
-			'item_brand' => esc_attr( $advanced_parameters->resolve_item_brand( $product ) ),
+			'item_brand' => $advanced_parameters->resolve_item_brand( $product ),
 			'item_id'    => esc_attr( $advanced_parameters->resolve_item_id( $product ) ),
 			'item_sku'   => esc_attr( $advanced_parameters->resolve_item_sku( $product ) ),
 			'price'      => $this->formatted_price( $product->get_price() ),

--- a/includes/class-gtm-server-side-wc-helpers.php
+++ b/includes/class-gtm-server-side-wc-helpers.php
@@ -56,11 +56,12 @@ class GTM_Server_Side_WC_Helpers {
 			)
 		);
 
+		$advanced_parameters = GTM_Server_Side_Advanced_Params::instance();
 		$result = array(
 			'item_name'  => esc_attr( $product->get_name() ),
-			'item_brand' => esc_attr( $this->get_product_brand( $product->get_id() ) ),
-			'item_id'    => esc_attr( $product->get_id() ),
-			'item_sku'   => esc_attr( $product->get_sku() ),
+			'item_brand' => esc_attr( $advanced_parameters->resolve_item_brand( $product->get_id() ) ),
+			'item_id'    => esc_attr( $advanced_parameters->resolve_item_id( $product ) ),
+			'item_sku'   => esc_attr( $advanced_parameters->resolve_item_sku( $product ) ),
 			'price'      => $this->formatted_price( $product->get_price() ),
 			'imageUrl'   => $this->get_product_image_url( $product ),
 		);

--- a/includes/class-gtm-server-side-webhook-completed.php
+++ b/includes/class-gtm-server-side-webhook-completed.php
@@ -52,7 +52,7 @@ class GTM_Server_Side_Webhook_Completed {
 			'event'     => 'order_completed',
 			'cart_hash' => $order->get_cart_hash(),
 			'ecommerce' => array(
-				'transaction_id'  => esc_attr( $order->get_order_number() ),
+				'transaction_id'  => esc_attr( GTM_Server_Side_Advanced_Params::instance()->resolve_transaction_id( $order ) ),
 				'affiliation'     => '',
 				'value'           => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'             => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),

--- a/includes/class-gtm-server-side-webhook-processing.php
+++ b/includes/class-gtm-server-side-webhook-processing.php
@@ -52,7 +52,7 @@ class GTM_Server_Side_Webhook_Processing {
 			'event'     => 'order_paid',
 			'cart_hash' => $order->get_cart_hash(),
 			'ecommerce' => array(
-				'transaction_id'  => esc_attr( $order->get_order_number() ),
+				'transaction_id'  => esc_attr( GTM_Server_Side_Advanced_Params::instance()->resolve_transaction_id( $order ) ),
 				'affiliation'     => '',
 				'value'           => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'             => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),

--- a/includes/class-gtm-server-side-webhook-purchase.php
+++ b/includes/class-gtm-server-side-webhook-purchase.php
@@ -52,7 +52,7 @@ class GTM_Server_Side_Webhook_Purchase {
 			'event'     => 'purchase',
 			'cart_hash' => $order->get_cart_hash(),
 			'ecommerce' => array(
-				'transaction_id'  => esc_attr( $order->get_order_number() ),
+				'transaction_id'  => esc_attr( GTM_Server_Side_Advanced_Params::instance()->resolve_transaction_id( $order ) ),
 				'affiliation'     => '',
 				'value'           => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'tax'             => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total_tax() ),

--- a/includes/class-gtm-server-side-webhook-refund.php
+++ b/includes/class-gtm-server-side-webhook-refund.php
@@ -53,7 +53,7 @@ class GTM_Server_Side_Webhook_Refund {
 			'event'     => 'refund',
 			'cart_hash' => $order->get_cart_hash(),
 			'ecommerce' => array(
-				'transaction_id' => esc_attr( $order->get_order_number() ),
+				'transaction_id' => esc_attr( GTM_Server_Side_Advanced_Params::instance()->resolve_transaction_id( $order ) ),
 				'value'          => GTM_Server_Side_WC_Helpers::instance()->formatted_price( $order->get_total() ),
 				'currency'       => esc_attr( $order->get_currency() ),
 				'items'          => GTM_Server_Side_WC_Helpers::instance()->get_order_data_layer_items( $order->get_items() ),

--- a/templates/class-gtm-server-side-admin.php
+++ b/templates/class-gtm-server-side-admin.php
@@ -75,6 +75,14 @@ $tab = GTM_Server_Side_Admin_Settings::get_settings_tab(); // phpcs:ignore WordP
 		<?php settings_fields( GTM_SERVER_SIDE_ADMIN_GROUP ); ?>
 		<?php do_settings_sections( GTM_SERVER_SIDE_ADMIN_SLUG ); ?>
 
+		<?php if ( 'data-layer' === $tab ) : ?>
+			<?php wp_nonce_field( 'meta-box-order', 'meta-box-order-nonce' ); ?>
+			<?php wp_nonce_field( 'closedpostboxes', 'closedpostboxesnonce' ); ?>
+			<div class="metabox-holder">
+				<?php do_meta_boxes( 'settings_page_' . GTM_SERVER_SIDE_ADMIN_SLUG, 'normal', null ); ?>
+			</div>
+		<?php endif; ?>
+
 		<?php if ( GTM_Server_Side_Admin_Settings_Webhooks::TAB === $tab ) : ?>
 			<table class="form-table" role="presentation">
 				<tbody>


### PR DESCRIPTION
# PRI-770: Wordpress dynamic DL

## What was added

- Added **Dynamic Data Layer settings** in the Data Layer admin tab as a new Advanced metabox.
- Added a new service class: `GTM_Server_Side_Advanced_Params` to store/sanitize/resolve dynamic values.
- Added configurable resolution for:
  - `item_id`
  - `item_sku`
  - `item_brand`
  - `transaction_id`

## Admin/UI changes
- Registered a new combined option: `gtm_server_side_adv`.
- Rendered a dedicated "Advanced Data Layer settings" metabox on the settings page.
- Added builder UI behavior in admin JS/CSS:
  - add/remove data points
  - optional prefix/separator
  - live result preview
  - reset to defaults
  - metabox toggle support, collapsed by default (saved as user preference)

<img width="1486" height="1034" alt="image" src="https://github.com/user-attachments/assets/6c3ced01-cc50-42c8-824b-a95254d604dd" />

## Runtime behavior changes

- Purchase event now resolves `ecommerce.transaction_id` via advanced settings.
- Webhooks (`purchase`, `processing`, `completed`, `refund`) now resolve `transaction_id` via advanced settings.
- `cart_state.lines` now uses advanced resolution for `item_id` and `item_sku`.
- Item brand in data layer now uses advanced resolver (including variation -> parent inheritance behavior).
- Custom `transaction_id` retrieval uses WooCommerce order meta API for HPOS compatibility.

## Other updates

- Version bumped to `2.2.0`.
- README/README.txt updated to document Dynamic Data Layer configuration and changelog entry.
- Minor JS refactor: migrated `var`/mutable declarations to `const` where applicable.
