### PR TITLE
PRI-772: WP same origin

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The **GTM Server Side** plugin by [stape.io](https://stape.io) is the easiest wa
 - Adds user data to Data Layer events.
 - Sends webhooks.
 - Provides the possibility to manage dynamic generation of data layer fields.
-– Native Same Origin proxy.
+- Native Same Origin proxy.
 
 ### Benefits
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Tested up to:** 7.0.0
 
-**Stable tag:** 2.2.0
+**Stable tag:** 2.3.0
 
 **License:** GPLv2 or later
 
@@ -28,6 +28,7 @@ The **GTM Server Side** plugin by [stape.io](https://stape.io) is the easiest wa
 - Adds user data to Data Layer events.
 - Sends webhooks.
 - Provides the possibility to manage dynamic generation of data layer fields.
+– Native Same Origin proxy.
 
 ### Benefits
 
@@ -85,6 +86,9 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.3.0
+- Introduction of Same Origin functionality.
 
 ## 2.2.0
 - Introduction of Dynamic Data Layer configuration.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
 Tested up to: 7.0.0
-Stable tag: 2.2.0
+Stable tag: 2.3.0
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -24,6 +24,7 @@ GTM Server Side plugin by stape.io features:
 * Adds user data to Data Layer events.
 * Sends webhooks.
 * Provides the possibility to manage dynamic generation of data layer fields.
+* Native Same Origin proxy.
 
 Benefits of GTM Server Side plugin by stape.io:
 
@@ -67,6 +68,9 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.3.0 =
+* Introduction of Same Origin functionality.
 
 = 2.2.0 =
 * Introduction of Dynamic Data Layer configuration.

--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -54,6 +54,125 @@
 	pointer-events: none;
 }
 
+/* ── Same-origin proxy card ────────────────────────────────────────────── */
+.gtm-so-card {
+	margin: 16px 0 24px;
+	padding: 4px 20px 12px;
+	background: #f0f6fc;
+	border: 1px solid #c5d9ed;
+	border-radius: 6px;
+}
+
+.gtm-so-card .form-table {
+	margin-top: 0;
+}
+
+.gtm-so-card .gtm-so-toggle-row th,
+.gtm-so-card .gtm-so-toggle-row td {
+	padding-top: 20px;
+}
+
+.gtm-so-beta {
+	display: inline-block;
+	margin-left: 8px;
+	padding: 2px 6px;
+	font-size: 10px;
+	font-weight: 700;
+	line-height: 1;
+	letter-spacing: .04em;
+	text-transform: uppercase;
+	color: #fff;
+	background: #d97706;
+	border-radius: 3px;
+	vertical-align: middle;
+}
+
+.gtm-so-toggle-wrap {
+	display: inline-flex;
+	align-items: center;
+	gap: 10px;
+}
+
+.gtm-so-input {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	margin: 0;
+	opacity: 0;
+}
+
+.gtm-so-switch {
+	position: relative;
+	display: inline-block;
+	width: 40px;
+	height: 22px;
+	cursor: pointer;
+}
+
+.gtm-so-slider {
+	position: absolute;
+	inset: 0;
+	background: #8c8f94;
+	border-radius: 22px;
+	transition: background .2s ease;
+}
+
+.gtm-so-slider::before {
+	content: '';
+	position: absolute;
+	top: 2px;
+	left: 2px;
+	width: 18px;
+	height: 18px;
+	background: #fff;
+	border-radius: 50%;
+	transition: transform .2s ease;
+}
+
+.gtm-so-input:checked ~ .gtm-so-switch .gtm-so-slider {
+	background: #2271b1;
+}
+
+.gtm-so-input:checked ~ .gtm-so-switch .gtm-so-slider::before {
+	transform: translateX(18px);
+}
+
+.gtm-so-input:focus-visible ~ .gtm-so-switch .gtm-so-slider {
+	box-shadow: 0 0 0 2px #fff, 0 0 0 4px #2271b1;
+}
+
+.gtm-so-state {
+	font-weight: 600;
+}
+
+.gtm-so-state::after {
+	content: 'Off';
+}
+
+.gtm-so-input:checked ~ .gtm-so-state::after {
+	content: 'On';
+}
+
+.gtm-so-desc {
+	margin: 10px 0 2px;
+	max-width: 660px;
+	color: #50575e;
+}
+
+/* Proxy fields live in the card but only show when the proxy is enabled. */
+.gtm-server-side-same-origin-field {
+	display: none;
+}
+
+#gtm-server-side-admin-settings:has( #gtm_server_side_same_origin_enable:checked ) .gtm-server-side-same-origin-field {
+	display: table-row;
+}
+
+/* Container URL / identifier / Cookie Keeper are hidden while the proxy is on. */
+#gtm-server-side-admin-settings:has( #gtm_server_side_same_origin_enable:checked ) .js-gtm-server-side-alternative-scenario {
+	display: none;
+}
+
 /* ── Advanced parameters postbox ───────────────────────────────────────── */
 
 #gtm-adv-params {

--- a/assets/js/admin-javascript.js
+++ b/assets/js/admin-javascript.js
@@ -102,6 +102,31 @@ jQuery( document ).ready(
 			}
 		);
 
+		if ( jQuery( '#gtm_server_side_same_origin_enable' ).length ) {
+			pluginGtmServerSide.initSameOrigin();
+			jQuery( '#gtm_server_side_same_origin_enable' ).on(
+				'click',
+				function() {
+					pluginGtmServerSide.initSameOrigin();
+					pluginGtmServerSide.changeWebIdentifier();
+				}
+			);
+			jQuery( '#gtm_server_side_same_origin_path' ).on(
+				'input',
+				function() {
+					pluginGtmServerSide.updateSameOriginTestState();
+				}
+			);
+			jQuery( document ).on(
+				'click',
+				'.js-gtm-server-side-test-same-origin',
+				function( e ) {
+					e.preventDefault();
+					pluginGtmServerSide.testSameOrigin();
+				}
+			);
+		}
+
 		pluginGtmServerSide.changeExcludeGtmUserRoles();
 		jQuery( '.js-gtm_server_side_gtm_exclude_roles' ).on(
 			'click',
@@ -386,10 +411,10 @@ const pluginGtmServerSide = {
 	},
 
 	changeExcludeGtmUserRoles: function() {
-		const $elRole = jQuery( '.js-gtm_server_side_gtm_exclude_roles' );
-		const $block  = jQuery( '.js-gtm-server-side-gtm-exclude-roles-block' );
+		const excludeRolesValue = jQuery( '.js-gtm_server_side_gtm_exclude_roles:checked' ).val();
+		const $block            = jQuery( '.js-gtm-server-side-gtm-exclude-roles-block' );
 
-		if ( $elRole.is( ':checked' ) ) {
+		if ( 'yes' === excludeRolesValue ) {
 			$block.show();
 		} else {
 			$block.hide();
@@ -402,7 +427,11 @@ const pluginGtmServerSide = {
 			return;
 		}
 
-		this.changeWebIdentifierCheckboxState( $elWebIdentifier, jQuery( '#gtm_server_side_cookie_keeper' ) );
+		const isSameOrigin = jQuery( '#gtm_server_side_same_origin_enable' ).is( ':checked' );
+		const $elApiKey    = jQuery( '#gtm_server_side_same_origin_api_key' );
+		const $source      = ( isSameOrigin && $elApiKey.length ) ? $elApiKey : $elWebIdentifier;
+
+		this.changeWebIdentifierCheckboxState( $source, jQuery( '#gtm_server_side_cookie_keeper' ) );
 	},
 
 	changeWebIdentifierCheckboxState: function( $elWebIdentifier, $el ) {
@@ -479,5 +508,73 @@ const pluginGtmServerSide = {
 		} );
 
 		$preview.text( prefix + parts.join( separator ) || '\u2014' );
+	},
+
+	/**
+	 * Position the Web GTM ID field for the current same-origin state.
+	 *
+	 * @return {void}
+	 */
+	initSameOrigin: function() {
+		const isSameOrigin = jQuery( '#gtm_server_side_same_origin_enable' ).is( ':checked' );
+		const $webIdRow    = jQuery( '#gtm_server_side_web_container_id' ).closest( 'tr' );
+
+		if ( $webIdRow.length ) {
+			if ( isSameOrigin ) {
+				$webIdRow.insertAfter( jQuery( '.gtm-so-webid-anchor' ) );
+			} else {
+				$webIdRow.insertAfter( jQuery( '#gtm_server_side_placement-disable' ).closest( 'tr' ) );
+			}
+		}
+
+		this.updateSameOriginTestState();
+	},
+
+	/**
+	 * Enable the "Test connection" button only when the saved path matches
+	 * the current input value (i.e. settings have been saved).
+	 *
+	 * @return {void}
+	 */
+	updateSameOriginTestState: function() {
+		if ( 'undefined' === typeof varGtmServerSide ) {
+			return;
+		}
+		const savedPath = varGtmServerSide.same_origin_path || '';
+		const currPath  = jQuery( '#gtm_server_side_same_origin_path' ).val() || '';
+		const $testBtn  = jQuery( '.js-gtm-server-side-test-same-origin' );
+		$testBtn.prop( 'disabled', savedPath !== currPath || '' === savedPath );
+	},
+
+	/**
+	 * Test the same-origin proxy connection by sending a browser-side GET
+	 * request with a random uid and verifying the plain-text echo response.
+	 *
+	 * @return {void}
+	 */
+	testSameOrigin: function() {
+		if ( 'undefined' === typeof varGtmServerSide || ! varGtmServerSide.same_origin_url ) {
+			return;
+		}
+
+		const uid      = Date.now().toString( 36 );
+		const $message = jQuery( '.js-gtm-server-side-same-origin-message' );
+		$message.html( '<i>Testing&hellip;</i>' );
+
+		jQuery.ajax( {
+			url:     varGtmServerSide.same_origin_url,
+			method:  'GET',
+			data:    { 'test-uid': uid },
+			success: function( response ) {
+				if ( String( response ).trim() === uid ) {
+					$message.html( '<span class="success">Connection successful!</span>' );
+				} else {
+					$message.html( '<span class="error">Connection failed: unexpected response.</span>' );
+				}
+			},
+			error: function() {
+				$message.html( '<span class="error">Connection failed.</span>' );
+			}
+		} );
 	},
 };

--- a/bootstrap.php
+++ b/bootstrap.php
@@ -80,6 +80,11 @@ define( 'GTM_SERVER_SIDE_CUST_MATCH_BACKFILL_FINISHED', 'gtm_server_side_cust_ma
 // d20260118.
 define( 'GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API', 'gtm_server_side_gtm_custom_loader_from_api' );
 
+// Tab: General — Same-Origin Proxy.
+define( 'GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE', 'gtm_server_side_same_origin_enable' );
+define( 'GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH', 'gtm_server_side_same_origin_path' );
+define( 'GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY', 'gtm_server_side_same_origin_api_key' );
+
 // Tab: Data Layer — Advanced parameters.
 define( 'GTM_SERVER_SIDE_FIELD_ADV', 'gtm_server_side_adv' );
 

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.2.0
+ * Version:           2.3.0
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+
@@ -32,6 +32,7 @@ register_deactivation_hook( __FILE__, array( GTM_Server_Side_Plugin_Deactivate::
 add_action( 'init', array( GTM_Server_Side_Plugin_Upgrade::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_I18n::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_WC_Order::class, 'instance' ) );
+add_action( 'gtm_server_side', array( GTM_Server_Side_Same_Origin_Proxy::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Customer_Loader_Cron::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Data_Manager_Ingest_Cron::class, 'instance' ) );
 add_action( 'gtm_server_side', array( GTM_Server_Side_Webhook_Purchase::class, 'instance' ) );

--- a/includes/class-gtm-server-side-admin-assets.php
+++ b/includes/class-gtm-server-side-admin-assets.php
@@ -39,8 +39,10 @@ class GTM_Server_Side_Admin_Assets {
 			'gtm-server-side-admin',
 			'varGtmServerSide',
 			array(
-				'ajax'     => admin_url( 'admin-ajax.php' ),
-				'security' => wp_create_nonce( GTM_SERVER_SIDE_AJAX_SECURITY ),
+				'ajax'             => admin_url( 'admin-ajax.php' ),
+				'security'         => wp_create_nonce( GTM_SERVER_SIDE_AJAX_SECURITY ),
+				'same_origin_path' => GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH ),
+				'same_origin_url'  => GTM_Server_Side_Helpers::get_same_origin_url(),
 			)
 		);
 	}

--- a/includes/class-gtm-server-side-admin-settings-general.php
+++ b/includes/class-gtm-server-side-admin-settings-general.php
@@ -32,6 +32,8 @@ class GTM_Server_Side_Admin_Settings_General {
 						name="' . esc_attr( GTM_SERVER_SIDE_FIELD_PLACEMENT ) . '"
 						value="' . esc_attr( GTM_SERVER_SIDE_FIELD_PLACEMENT_VALUE_PLUGIN ) . '">';
 				}
+
+				self::render_same_origin_card();
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG
 		);
@@ -205,6 +207,14 @@ class GTM_Server_Side_Admin_Settings_General {
 			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL
 		);
 
+		register_setting(
+			GTM_SERVER_SIDE_ADMIN_GROUP,
+			GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE,
+			array(
+				'sanitize_callback' => 'GTM_Server_Side_Helpers::sanitize_bool',
+			)
+		);
+
 		register_setting( GTM_SERVER_SIDE_ADMIN_GROUP, GTM_SERVER_SIDE_FIELD_WEB_CONTAINER_URL );
 		add_settings_field(
 			GTM_SERVER_SIDE_FIELD_WEB_CONTAINER_URL,
@@ -225,7 +235,8 @@ class GTM_Server_Side_Admin_Settings_General {
 				);
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG,
-			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL
+			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL,
+			array( 'class' => 'js-gtm-server-side-alternative-scenario' )
 		);
 
 		register_setting( GTM_SERVER_SIDE_ADMIN_GROUP, GTM_SERVER_SIDE_FIELD_WEB_IDENTIFIER );
@@ -250,7 +261,24 @@ class GTM_Server_Side_Admin_Settings_General {
 				);
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG,
-			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL
+			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL,
+			array( 'class' => 'js-gtm-server-side-alternative-scenario' )
+		);
+
+		register_setting(
+			GTM_SERVER_SIDE_ADMIN_GROUP,
+			GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH,
+			array(
+				'sanitize_callback' => 'GTM_Server_Side_Helpers::sanitize_same_origin_path',
+			)
+		);
+
+		register_setting(
+			GTM_SERVER_SIDE_ADMIN_GROUP,
+			GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY,
+			array(
+				'sanitize_callback' => 'sanitize_text_field',
+			)
 		);
 
 		register_setting(
@@ -279,7 +307,91 @@ class GTM_Server_Side_Admin_Settings_General {
 				);
 			},
 			GTM_SERVER_SIDE_ADMIN_SLUG,
-			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL
+			GTM_SERVER_SIDE_ADMIN_GROUP_GENERAL,
+			array( 'class' => 'js-gtm-server-side-alternative-scenario' )
 		);
+	}
+
+	/**
+	 * Render the same-origin proxy card shown at the top of the General tab.
+	 *
+	 * @return void
+	 */
+	public static function render_same_origin_card() {
+		$toggle_id = GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE;
+		?>
+		<div class="gtm-so-card">
+			<table class="form-table gtm-so-card-table" role="presentation">
+				<tbody>
+					<tr class="gtm-so-toggle-row">
+						<th scope="row">
+							<?php esc_html_e( 'Same-origin proxy', 'gtm-server-side' ); ?>
+							<span class="gtm-so-beta"><?php esc_html_e( 'Beta', 'gtm-server-side' ); ?></span>
+						</th>
+						<td>
+							<span class="gtm-so-toggle-wrap">
+								<input
+									type="checkbox"
+									class="gtm-so-input"
+									id="<?php echo esc_attr( $toggle_id ); ?>"
+									name="<?php echo esc_attr( $toggle_id ); ?>"
+									<?php checked( GTM_Server_Side_Helpers::get_option( $toggle_id ), GTM_SERVER_SIDE_FIELD_VALUE_YES ); ?>
+									value="yes">
+								<label class="gtm-so-switch" for="<?php echo esc_attr( $toggle_id ); ?>"><span class="gtm-so-slider"></span></label>
+								<span class="gtm-so-state"></span>
+							</span>
+							<p class="gtm-so-desc">
+								<?php
+								echo wp_kses(
+									__( 'The GTM loader is served from Stape through <strong>your own WordPress server</strong>, so it loads first-party. The proxying runs on infrastructure you control, and its load scales with your traffic.', 'gtm-server-side' ),
+									array( 'strong' => array() )
+								);
+								?>
+							</p>
+						</td>
+					</tr>
+					<tr class="gtm-so-webid-anchor" style="display:none"><td></td></tr>
+					<tr class="gtm-server-side-same-origin-field">
+						<th scope="row"><?php esc_html_e( 'Proxy path', 'gtm-server-side' ); ?></th>
+						<td>
+							<input
+								type="text"
+								id="<?php echo esc_attr( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH ); ?>"
+								name="<?php echo esc_attr( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH ); ?>"
+								pattern="/.+"
+								value="<?php echo esc_attr( GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH ) ); ?>">
+							<button type="button" class="button js-gtm-server-side-test-same-origin" disabled><?php esc_html_e( 'Test connection', 'gtm-server-side' ); ?></button>
+							<span class="js-gtm-server-side-same-origin-message"></span>
+							<br>
+							<?php esc_html_e( 'The path on this domain that requests are proxied through. Must start with a slash. Save settings before testing.', 'gtm-server-side' ); ?>
+						</td>
+					</tr>
+					<tr class="gtm-server-side-same-origin-field">
+						<th scope="row"><?php esc_html_e( 'Container API key', 'gtm-server-side' ); ?></th>
+						<td>
+							<input
+								type="text"
+								id="<?php echo esc_attr( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY ); ?>"
+								name="<?php echo esc_attr( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY ); ?>"
+								value="<?php echo esc_attr( GTM_Server_Side_Helpers::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY ) ); ?>">
+							<br>
+							<?php
+							echo wp_kses(
+								__( 'Paste your container API key, found under <a href="https://app.stape.io" target="_blank">Stape container settings</a> — <strong>not the container identifier</strong>.', 'gtm-server-side' ),
+								array(
+									'a'      => array(
+										'href'   => array(),
+										'target' => array(),
+									),
+									'strong' => array(),
+								)
+							);
+							?>
+						</td>
+					</tr>
+				</tbody>
+			</table>
+		</div>
+		<?php
 	}
 }

--- a/includes/class-gtm-server-side-admin-settings.php
+++ b/includes/class-gtm-server-side-admin-settings.php
@@ -27,6 +27,9 @@ class GTM_Server_Side_Admin_Settings {
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_WEB_IDENTIFIER, array( $this, 'clear_cache_field' ), 10, 2 );
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_WEB_CONTAINER_ID, array( $this, 'clear_cache_field' ), 10, 2 );
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_CUST_MATCH_BACKFILL, array( $this, 'change_option_backfill' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE, array( $this, 'clear_cache_field' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH, array( $this, 'clear_cache_field' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY, array( $this, 'clear_cache_field' ), 10, 2 );
 	}
 
 	/**

--- a/includes/class-gtm-server-side-customer-loader-handler.php
+++ b/includes/class-gtm-server-side-customer-loader-handler.php
@@ -21,6 +21,84 @@ class GTM_Server_Side_Customer_Loader_Handler {
 	 * @return mixed
 	 */
 	public function send_data() {
+		$request_context = $this->get_request_context();
+		if ( is_wp_error( $request_context ) ) {
+			return $request_context;
+		}
+
+		$global_url = sprintf(
+			'https://api.app.stape.io/api/v2/container/%s/custom-loader',
+			rawurlencode( $request_context['identifier'] )
+		);
+
+		$response = $this->request_custom_loader( $global_url, $request_context['data'] );
+
+		if ( is_wp_error( $response ) ) {
+			return $response;
+		}
+
+		$status_code = (int) wp_remote_retrieve_response_code( $response );
+
+		/**
+		 * Retry only on 404.
+		 */
+		if ( 404 === $status_code ) {
+			$eu_url = sprintf(
+				'https://api.app.eu.stape.io/api/v2/container/%s/custom-loader',
+				rawurlencode( $request_context['identifier'] )
+			);
+
+			$response = $this->request_custom_loader( $eu_url, $request_context['data'] );
+
+			if ( is_wp_error( $response ) ) {
+				return $response;
+			}
+		}
+
+		return $this->parse_response( $response, $request_context['data'] );
+	}
+
+	/**
+	 * Execute custom loader request.
+	 *
+	 * @param string $url  Endpoint URL.
+	 * @param array  $data Request data.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function request_custom_loader( $url, $data ) {
+		return wp_remote_post(
+			$url,
+			array(
+				'headers' => array(
+					'accept'       => '*/*',
+					'content-type' => 'application/json',
+				),
+				'body'    => wp_json_encode( $data ),
+				'timeout' => 20,
+			)
+		);
+	}
+
+	/**
+	 * Build custom-loader request context for current mode.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function get_request_context() {
+		if ( GTM_Server_Side_Helpers::has_same_origin_settings() ) {
+			return $this->get_same_origin_request_context();
+		}
+
+		return $this->get_default_request_context();
+	}
+
+	/**
+	 * Build custom-loader request context for the default mode.
+	 *
+	 * @return array|WP_Error
+	 */
+	private function get_default_request_context() {
 		$gtm_container_identifier = GTM_Server_Side_Helpers::get_raw_gtm_container_identifier();
 		if ( empty( $gtm_container_identifier ) ) {
 			return new WP_Error( 'missing_container_identifier', 'GTM Container Identifier is missing.' );
@@ -58,57 +136,60 @@ class GTM_Server_Side_Customer_Loader_Handler {
 			$data['userIdentifierValue'] = GTM_SERVER_SIDE_COOKIE_KEEPER_NAME;
 		}
 
-		$global_url = sprintf(
-			'https://api.app.stape.io/api/v2/container/%s/custom-loader',
-			rawurlencode( $gtm_container_identifier )
+		return array(
+			'identifier' => $gtm_container_identifier,
+			'data'       => $data,
 		);
-
-		$response = $this->request_custom_loader( $global_url, $data );
-
-		if ( is_wp_error( $response ) ) {
-			return $response;
-		}
-
-		$status_code = (int) wp_remote_retrieve_response_code( $response );
-
-		/**
-		 * Retry only on 404.
-		 */
-		if ( 404 === $status_code ) {
-			$eu_url = sprintf(
-				'https://api.app.eu.stape.io/api/v2/container/%s/custom-loader',
-				rawurlencode( $gtm_container_identifier )
-			);
-
-			$response = $this->request_custom_loader( $eu_url, $data );
-
-			if ( is_wp_error( $response ) ) {
-				return $response;
-			}
-		}
-
-		return $this->parse_response( $response, $data );
 	}
 
 	/**
-	 * Execute custom loader request.
-	 *
-	 * @param string $url  Endpoint URL.
-	 * @param array  $data Request data.
+	 * Build custom-loader request context for same-origin mode.
 	 *
 	 * @return array|WP_Error
 	 */
-	private function request_custom_loader( $url, $data ) {
-		return wp_remote_post(
-			$url,
-			array(
-				'headers' => array(
-					'accept'       => '*/*',
-					'content-type' => 'application/json',
-				),
-				'body'    => wp_json_encode( $data ),
-				'timeout' => 20,
-			)
+	private function get_same_origin_request_context() {
+		$api_key = GTM_Server_Side_Helpers::get_same_origin_api_key();
+		if ( '' === trim( $api_key ) ) {
+			return new WP_Error( 'missing_same_origin_api_key', 'Stape same-origin API key is missing.' );
+		}
+
+		$parsed = GTM_Server_Side_Helpers::parse_stape_api_key( $api_key );
+		if ( null === $parsed ) {
+			return new WP_Error( 'invalid_same_origin_api_key', 'Stape same-origin API key format is invalid.' );
+		}
+
+		$gtm_container_id = GTM_Server_Side_Helpers::get_raw_gtm_container_id();
+		if ( empty( $gtm_container_id ) ) {
+			return new WP_Error( 'missing_container_id', 'GTM Container ID is missing.' );
+		}
+
+		$same_origin_url = GTM_Server_Side_Helpers::get_same_origin_url();
+		$parsed_url      = wp_parse_url( $same_origin_url );
+		$domain          = '';
+
+		if ( ! empty( $parsed_url['host'] ) ) {
+			$domain = $parsed_url['host'];
+			if ( ! empty( $parsed_url['port'] ) ) {
+				$domain .= ':' . $parsed_url['port'];
+			}
+		}
+
+		$same_origin_path = '';
+		if ( ! empty( $parsed_url['path'] ) ) {
+			$same_origin_path = $parsed_url['path'];
+		}
+
+		$data = array(
+			'webGtmId'            => $gtm_container_id,
+			'domain'              => $domain,
+			'sameOriginPath'      => $same_origin_path,
+			'source'              => 'wordpress',
+			'dataLayerObjectName' => 'dataLayer',
+		);
+
+		return array(
+			'identifier' => $parsed[1],
+			'data'       => $data,
 		);
 	}
 

--- a/includes/class-gtm-server-side-customer-loader-options-watcher.php
+++ b/includes/class-gtm-server-side-customer-loader-options-watcher.php
@@ -39,6 +39,9 @@ class GTM_Server_Side_Customer_Loader_Options_Watcher {
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_WEB_CONTAINER_ID, array( $this, 'update_option' ), 10, 2 );
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_WEB_CONTAINER_URL, array( $this, 'update_option' ), 10, 2 );
 		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_COOKIE_KEEPER, array( $this, 'update_option' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE, array( $this, 'update_option' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH, array( $this, 'update_option' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY, array( $this, 'update_option' ), 10, 2 );
 	}
 
 	/**
@@ -61,7 +64,14 @@ class GTM_Server_Side_Customer_Loader_Options_Watcher {
 			! empty( $result['body'] ) &&
 			! empty( $result['body']['jsCode'] )
 		) {
-			update_option( GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API, $result['body']['jsCode'] );
+			$js_code = (string) $result['body']['jsCode'];
+
+			if ( GTM_Server_Side_Helpers::has_same_origin_settings() ) {
+				// jsCode is generated for the same-origin context, so every ".js" reference in it must land on the proxy as ".load" to avoid static file server.
+				$js_code = preg_replace( '/\.js(?=(\?|"|\'))/', '.load', $js_code );
+			}
+
+			update_option( GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API, $js_code );
 			return;
 		}
 

--- a/includes/class-gtm-server-side-handler-data-manager-ingest.php
+++ b/includes/class-gtm-server-side-handler-data-manager-ingest.php
@@ -292,11 +292,12 @@ class GTM_Server_Side_Handler_Data_Manager_Ingest {
 		$endpoint = '';
 		$api_key  = GTM_Server_Side_Helpers::get_stape_container_api_key();
 		if ( $api_key ) {
-			$a          = explode( ':', $api_key );
-			$domain_end = isset( $a[3] ) ? $a[3] : 'io';
-			$url        = 'https://' . $a[1] . '.' . $a[0] . '.stape.' . $domain_end;
-			$path       = '/stape-api/' . $a[2] . '/v2/data-manager/ingest';
-			$endpoint   = $url . $path;
+			$parsed = GTM_Server_Side_Helpers::parse_stape_api_key( $api_key );
+			if ( null !== $parsed ) {
+				$url      = 'https://' . $parsed[1] . '.' . $parsed[0] . '.stape.' . $parsed[3];
+				$path     = '/stape-api/' . $parsed[2] . '/v2/data-manager/ingest';
+				$endpoint = $url . $path;
+			}
 		}
 
 		/**

--- a/includes/class-gtm-server-side-helpers.php
+++ b/includes/class-gtm-server-side-helpers.php
@@ -257,7 +257,11 @@ class GTM_Server_Side_Helpers {
 	public static function sanitize_same_origin_path( $value ) {
 		$value = trim( (string) $value );
 
-		if ( '' !== $value && '/' !== $value[0] ) {
+		if ( '' === $value ) {
+			return '';
+		}
+
+		if ( '/' !== $value[0] ) {
 			add_settings_error(
 				GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH,
 				'gtm_server_side_same_origin_path_invalid',
@@ -265,6 +269,10 @@ class GTM_Server_Side_Helpers {
 			);
 			return self::get_raw_same_origin_path();
 		}
+
+		// Drop any query/fragment if the user pasted it, and normalize duplicate slashes.
+		$value = preg_replace( '/[?#].*$/', '', $value );
+		$value = preg_replace( '#/+#', '/', $value );
 
 		return $value;
 	}

--- a/includes/class-gtm-server-side-helpers.php
+++ b/includes/class-gtm-server-side-helpers.php
@@ -130,6 +130,146 @@ class GTM_Server_Side_Helpers {
 	}
 
 	/**
+	 * Return the raw same-origin proxy path (e.g. '/gtm/').
+	 *
+	 * @return string
+	 */
+	public static function get_raw_same_origin_path() {
+		return (string) self::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH );
+	}
+
+	/**
+	 * Return the Stape same-origin API key.
+	 *
+	 * @return string
+	 */
+	public static function get_same_origin_api_key() {
+		return (string) self::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY );
+	}
+
+	/**
+	 * Whether the same-origin proxy is enabled.
+	 *
+	 * @return bool
+	 */
+	public static function is_enable_same_origin() {
+		return GTM_SERVER_SIDE_FIELD_VALUE_YES === self::get_option( GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE );
+	}
+
+	/**
+	 * Whether all three same-origin settings are configured.
+	 *
+	 * @return bool
+	 */
+	public static function has_same_origin_settings() {
+		return self::is_enable_same_origin()
+			&& '' !== self::get_raw_same_origin_path()
+			&& '' !== self::get_same_origin_api_key();
+	}
+
+	/**
+	 * Parse a Stape API key into its component segments.
+	 *
+	 * Format: a0:a1:a2[:a3] where a3 is the TLD (defaults to 'io').
+	 * Returns null when any of the first three segments are missing or empty.
+	 *
+	 * @param  string $key Raw API key.
+	 * @return array|null  Indexed array [0..3] or null on parse failure.
+	 */
+	public static function parse_stape_api_key( $key ) {
+		$parts = explode( ':', trim( (string) $key ) );
+		if (
+			count( $parts ) < 3 ||
+			'' === $parts[0] ||
+			'' === $parts[1] ||
+			'' === $parts[2]
+		) {
+			return null;
+		}
+
+		return array(
+			0 => $parts[0],
+			1 => $parts[1],
+			2 => $parts[2],
+			3 => ( isset( $parts[3] ) && '' !== $parts[3] ) ? $parts[3] : 'io',
+		);
+	}
+
+	/**
+	 * Derive the upstream sGTM endpoint URL from the API key.
+	 *
+	 * The API key is colon-separated: a0:a1:a2:a3 where the optional a3 is
+	 * the TLD (defaults to 'io'). The endpoint is: https://a1.a0.stape.{tld}
+	 *
+	 * @return string  Empty string when the key is malformed.
+	 */
+	public static function get_same_origin_endpoint() {
+		$parsed = self::parse_stape_api_key( self::get_same_origin_api_key() );
+		if ( null === $parsed ) {
+			return '';
+		}
+
+		return 'https://' . $parsed[1] . '.' . $parsed[0] . '.stape.' . $parsed[3];
+	}
+
+	/**
+	 * Return the same-origin proxy path with a guaranteed leading slash.
+	 *
+	 * Use this wherever the path is assembled into a URL. The raw stored
+	 * value is left untouched so the admin always sees what they typed.
+	 *
+	 * @return string
+	 */
+	public static function get_same_origin_path() {
+		$path = self::get_raw_same_origin_path();
+		if ( '' !== $path && '/' !== $path[0] ) {
+			$path = '/' . $path;
+		}
+		return $path;
+	}
+
+	/**
+	 * Absolute URL to the same-origin proxy path on this site.
+	 *
+	 * Built from home_url() so it reflects WordPress's canonical host, scheme
+	 * and (sub-directory) path. Used directly as the connection-test target in
+	 * the admin, and decomposed into host + path when registering the custom
+	 * loader with Stape.
+	 *
+	 * @return string  Empty string when no path is configured.
+	 */
+	public static function get_same_origin_url() {
+		if ( '' === self::get_raw_same_origin_path() ) {
+			return '';
+		}
+		return home_url( self::get_same_origin_path() );
+	}
+
+	/**
+	 * Sanitize a same-origin path value.
+	 * Trims whitespace; the trailing slash is preserved if the user included it.
+	 * Rejects values that don't start with '/' and keeps the previously saved
+	 * value instead, surfacing a settings error to the admin.
+	 *
+	 * @param  mixed $value Raw input value.
+	 * @return string
+	 */
+	public static function sanitize_same_origin_path( $value ) {
+		$value = trim( (string) $value );
+
+		if ( '' !== $value && '/' !== $value[0] ) {
+			add_settings_error(
+				GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH,
+				'gtm_server_side_same_origin_path_invalid',
+				__( 'Same-origin proxy path must start with "/" (e.g. /gtm/). The previous value was kept.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN )
+			);
+			return self::get_raw_same_origin_path();
+		}
+
+		return $value;
+	}
+
+	/**
 	 * Return gtm exclude list roles.
 	 *
 	 * @return array
@@ -217,12 +357,16 @@ class GTM_Server_Side_Helpers {
 	 * @return string
 	 */
 	public static function get_gtm_container_url() {
+		if ( self::has_same_origin_settings() && self::has_gtm_custom_loader_from_api()) {
+			return rtrim( home_url( self::get_same_origin_path() ), '/' );
+		}
+
 		$url = self::get_raw_gtm_container_url();
 
 		if ( empty( $url ) ) {
 			return 'https://www.googletagmanager.com';
 		}
-
+		
 		return $url;
 	}
 
@@ -232,6 +376,11 @@ class GTM_Server_Side_Helpers {
 	 * @return string
 	 */
 	public static function get_gtm_container_identifier() {
+		if ( self::has_same_origin_settings() ) {
+			$parsed = self::parse_stape_api_key( self::get_same_origin_api_key() );
+			return ( null !== $parsed ) ? $parsed[1] : 'gtm';
+		}
+
 		if ( ! self::has_gtm_container_identifier() ) {
 			return 'gtm';
 		}
@@ -309,7 +458,7 @@ class GTM_Server_Side_Helpers {
 	 */
 	public static function is_enable_cookie_keeper() {
 		if ( null === static::$is_enable_cookie_keeper ) {
-			static::$is_enable_cookie_keeper = GTM_SERVER_SIDE_FIELD_VALUE_YES === self::get_option( GTM_SERVER_SIDE_FIELD_COOKIE_KEEPER );
+			static::$is_enable_cookie_keeper = GTM_SERVER_SIDE_FIELD_VALUE_YES === self::get_option( GTM_SERVER_SIDE_FIELD_COOKIE_KEEPER ) && ! self::has_same_origin_settings();
 		}
 
 		return static::$is_enable_cookie_keeper;

--- a/includes/class-gtm-server-side-plugin-activate.php
+++ b/includes/class-gtm-server-side-plugin-activate.php
@@ -40,5 +40,7 @@ class GTM_Server_Side_Plugin_Activate {
 		if ( empty( get_option( GTM_SERVER_SIDE_FIELD_DATA_LAYER_CUSTOM_EVENT_NAME ) ) ) {
 			update_option( GTM_SERVER_SIDE_FIELD_DATA_LAYER_CUSTOM_EVENT_NAME, GTM_SERVER_SIDE_FIELD_VALUE_YES );
 		}
+
+		GTM_Server_Side_Same_Origin_Proxy::flush_rules();
 	}
 }

--- a/includes/class-gtm-server-side-plugin-deactivate.php
+++ b/includes/class-gtm-server-side-plugin-deactivate.php
@@ -23,5 +23,6 @@ class GTM_Server_Side_Plugin_Deactivate {
 	public function init() {
 		GTM_Server_Side_Customer_Loader_Cron::instance()->deactivation();
 		GTM_Server_Side_Data_Manager_Ingest_Cron::instance()->deactivation();
+		GTM_Server_Side_Same_Origin_Proxy::instance()->deactivation();
 	}
 }

--- a/includes/class-gtm-server-side-same-origin-proxy.php
+++ b/includes/class-gtm-server-side-same-origin-proxy.php
@@ -9,7 +9,7 @@
  *
  * @package    GTM_Server_Side
  * @subpackage GTM_Server_Side/includes
- * @since      2.2.0
+ * @since      2.3.0
  */
 
 defined( 'ABSPATH' ) || exit;

--- a/includes/class-gtm-server-side-same-origin-proxy.php
+++ b/includes/class-gtm-server-side-same-origin-proxy.php
@@ -1,0 +1,412 @@
+<?php
+/**
+ * Same-Origin Proxy.
+ *
+ * Registers a WordPress rewrite rule so that requests to the configured
+ * path are transparently forwarded to the Stape sGTM container endpoint.
+ * Relies entirely on WordPress's native rewrite system — no REQUEST_URI
+ * string parsing.
+ *
+ * @package    GTM_Server_Side
+ * @subpackage GTM_Server_Side/includes
+ * @since      2.2.0
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Same-Origin Proxy handler.
+ */
+class GTM_Server_Side_Same_Origin_Proxy {
+	use GTM_Server_Side_Singleton;
+
+	/**
+	 * Query variable that signals a proxy request.
+	 */
+	const QUERY_VAR = 'gtm_server_side_proxy';
+
+	/**
+	 * Query variable that carries the sub-path after the proxy prefix.
+	 */
+	const PATH_VAR = 'gtm_server_side_proxy_path';
+
+	/**
+	 * Whether a rewrite-rules flush has already been scheduled for shutdown.
+	 *
+	 * @var bool
+	 */
+	private $flush_scheduled = false;
+
+	/**
+	 * Allowed HTTP methods for the upstream request.
+	 *
+	 * @var string[]
+	 */
+	private static $allowed_methods = array( 'GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'HEAD', 'OPTIONS' );
+
+	/**
+	 * HTTP methods that carry a request body and should forward one upstream.
+	 * DELETE is included since some APIs accept a DELETE payload.
+	 *
+	 * @var string[]
+	 */
+	private static $body_methods = array( 'POST', 'PUT', 'PATCH', 'DELETE' );
+
+	/**
+	 * Hop-by-hop headers that must not be forwarded to the upstream.
+	 *
+	 * @var string[]
+	 */
+	private static $hop_by_hop_request = array(
+		'host',
+		'connection',
+		'keep-alive',
+		'proxy-authenticate',
+		'proxy-authorization',
+		'te',
+		'trailer',
+		'transfer-encoding',
+		'upgrade',
+		'expect',
+		'content-length',
+		'accept-encoding',
+	);
+
+	/**
+	 * Hop-by-hop headers that must not be forwarded to the browser.
+	 *
+	 * @var string[]
+	 */
+	private static $hop_by_hop_response = array(
+		'connection',
+		'keep-alive',
+		'transfer-encoding',
+		'content-encoding',
+		'content-length',
+		'te',
+		'trailer',
+		'upgrade',
+	);
+
+	/**
+	 * Security response headers deliberately stripped from the upstream reply.
+	 *
+	 * @var string[]
+	 */
+	private static $stripped_security_response = array(
+		'x-frame-options',
+		'x-content-type-options',
+		'referrer-policy',
+	);
+
+	/**
+	 * Register hooks.
+	 *
+	 * @return void
+	 */
+	public function init() {
+		add_action( 'init', array( $this, 'register_rewrite_rule' ) );
+
+		add_filter( 'query_vars', array( $this, 'register_query_vars' ) );
+		add_action( 'template_redirect', array( $this, 'handle_request' ), 0 );
+
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_ENABLE, array( $this, 'on_option_change' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH, array( $this, 'on_option_change' ), 10, 2 );
+		add_action( 'update_option_' . GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_API_KEY, array( $this, 'on_option_change' ), 10, 2 );
+	}
+
+	/**
+	 * Add the rewrite rule for the proxy path to WordPress's rewrite table.
+	 *
+	 * @return void
+	 */
+	public function register_rewrite_rule() {
+		if ( ! GTM_Server_Side_Helpers::is_enable_same_origin() ) {
+			return;
+		}
+
+		$raw_path = GTM_Server_Side_Helpers::get_raw_same_origin_path();
+		if ( '' === $raw_path ) {
+			return;
+		}
+
+		// Trim slashes so the regex anchor works correctly regardless of
+		// whether the stored path has a leading/trailing slash.
+		$path = trim( $raw_path, '/' );
+		if ( '' === $path ) {
+			return;
+		}
+
+		add_rewrite_rule(
+			'^' . preg_quote( $path, '/' ) . '(/.*)?$',
+			'index.php?' . self::QUERY_VAR . '=1&' . self::PATH_VAR . '=$matches[1]',
+			'top'
+		);
+	}
+
+	/**
+	 * Expose our query variables to WordPress.
+	 *
+	 * @param  string[] $vars Existing public query vars.
+	 * @return string[]
+	 */
+	public function register_query_vars( array $vars ) {
+		$vars[] = self::QUERY_VAR;
+		$vars[] = self::PATH_VAR;
+		return $vars;
+	}
+
+	/**
+	 * Flush rewrite rules whenever a relevant setting changes so the stored
+	 * rewrite_rules option and .htaccess stay in sync.
+	 *
+	 * @param  mixed $old_value Previous option value.
+	 * @param  mixed $new_value New option value.
+	 * @return void
+	 */
+	public function on_option_change( $old_value, $new_value ) {
+		if ( $old_value === $new_value ) {
+			return;
+		}
+		$this->schedule_flush();
+	}
+
+	/**
+	 * Schedule a single rewrite-rules flush to run once on `shutdown`,
+	 * regardless of how many option changes occur during the request.
+	 *
+	 * @return void
+	 */
+	private function schedule_flush() {
+		if ( $this->flush_scheduled ) {
+			return;
+		}
+		$this->flush_scheduled = true;
+		add_action( 'shutdown', array( $this, 'do_scheduled_flush' ) );
+	}
+
+	/**
+	 * Perform the debounced flush. Re-registers the rewrite rule first so the
+	 * regenerated rule set reflects the just-saved options (e.g. when the
+	 * feature was enabled during this request, after 'init' already ran).
+	 *
+	 * @return void
+	 */
+	public function do_scheduled_flush() {
+		$this->register_rewrite_rule();
+		flush_rewrite_rules();
+	}
+
+	/**
+	 * Static helper used by the activation and deactivation hooks to flush
+	 * rewrite rules without needing a fully booted singleton.
+	 *
+	 * @return void
+	 */
+	public static function flush_rules() {
+		$instance = self::instance();
+		$instance->register_rewrite_rule();
+		flush_rewrite_rules();
+	}
+
+	/**
+	 * Deactivation handler.
+	 *
+	 * Flushes rewrite rules after plugin hooks are removed so the persisted
+	 * rule set no longer contains the same-origin proxy rewrite.
+	 *
+	 * @return void
+	 */
+	public function deactivation() {
+		flush_rewrite_rules();
+	}
+
+	/**
+	 * Route handler — only acts when the proxy query var is set to '1'.
+	 *
+	 * @return void
+	 */
+	public function handle_request() {
+		if ( '1' !== (string) get_query_var( self::QUERY_VAR ) ) {
+			return;
+		}
+
+		if ( ! GTM_Server_Side_Helpers::is_enable_same_origin() ) {
+			return;
+		}
+
+		// Connection test: echo the provided uid as plain text and exit.
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$test_uid = isset( $_GET['test-uid'] ) ? sanitize_text_field( wp_unslash( $_GET['test-uid'] ) ) : '';
+		if ( '' !== $test_uid ) {
+			header( 'Content-Type: text/plain; charset=utf-8' );
+			header( 'Cache-Control: no-store' );
+			echo esc_html( $test_uid );
+			exit;
+		}
+
+		if ( ! GTM_Server_Side_Helpers::has_same_origin_settings() ) {
+			status_header( 404 );
+			exit;
+		}
+
+		$endpoint = GTM_Server_Side_Helpers::get_same_origin_endpoint();
+		if ( '' === $endpoint ) {
+			status_header( 502 );
+			exit;
+		}
+
+		// Sub-path captured by the rewrite rule, e.g. '/collect' or ''.
+		$sub_path              = (string) get_query_var( self::PATH_VAR );
+		$is_custom_loader_load = (bool) preg_match( '/\.load$/i', $sub_path );
+		$upstream_path         = $is_custom_loader_load
+			? (string) preg_replace( '/\.load$/i', '.js', $sub_path )
+			: $sub_path;
+		$url                   = $endpoint . $upstream_path;
+
+		// Forward the original query string unchanged.
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$qs = isset( $_SERVER['QUERY_STRING'] ) ? (string) $_SERVER['QUERY_STRING'] : '';
+		if ( '' !== $qs ) {
+			$url .= '?' . $qs;
+		}
+
+		$response = wp_remote_request(
+			$url,
+			array(
+				'method'      => $this->get_request_method(),
+				'headers'     => $this->get_forward_headers(),
+				'body'        => $this->get_request_body(),
+				'timeout'     => 20,
+				'redirection' => 0,
+				'sslverify'   => true,
+			)
+		);
+
+		if ( is_wp_error( $response ) ) {
+			status_header( 502 );
+			exit;
+		}
+
+		$status = (int) wp_remote_retrieve_response_code( $response );
+		status_header( $status > 0 ? $status : 502 );
+
+		$this->send_response_headers( wp_remote_retrieve_headers( $response ) );
+
+		if ( $is_custom_loader_load ) {
+			header( 'Content-Type: application/javascript; charset=utf-8', true );
+		}
+
+		// Drain any WordPress output buffers (e.g. ob_gzhandler) so they
+		// cannot re-compress the already-decoded upstream body.
+		while ( ob_get_level() > 0 ) {
+			ob_end_clean();
+		}
+
+		// phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+		echo wp_remote_retrieve_body( $response );
+		exit;
+	}
+
+	/**
+	 * Return the HTTP method for the upstream request, validated against an
+	 * allowlist to prevent header injection.
+	 *
+	 * @return string
+	 */
+	private function get_request_method() {
+		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$method = strtoupper( isset( $_SERVER['REQUEST_METHOD'] ) ? (string) $_SERVER['REQUEST_METHOD'] : 'GET' );
+		return in_array( $method, self::$allowed_methods, true ) ? $method : 'GET';
+	}
+
+	/**
+	 * Read the raw request body, but only for methods that carry one.
+	 *
+	 * @return string|null  Raw body for body-bearing methods, null otherwise.
+	 */
+	private function get_request_body() {
+		if ( ! in_array( $this->get_request_method(), self::$body_methods, true ) ) {
+			return null;
+		}
+
+		// phpcs:ignore WordPress.WP.AlternativeFunctions
+		return file_get_contents( 'php://input' );
+	}
+
+	/**
+	 * Build the set of request headers to forward upstream.
+	 * Removes hop-by-hop headers and adds x-stape-host.
+	 *
+	 * @return array<string,string>
+	 */
+	private function get_forward_headers() {
+		$all = function_exists( 'getallheaders' ) ? getallheaders() : $this->get_headers_from_server();
+
+		$out = array();
+		foreach ( $all as $key => $value ) {
+			if ( ! in_array( strtolower( $key ), self::$hop_by_hop_request, true ) ) {
+				$out[ $key ] = $value;
+			}
+		}
+
+		$out['x-stape-host'] = (string) wp_parse_url( home_url(), PHP_URL_HOST );
+
+		return $out;
+	}
+
+	/**
+	 * Reconstruct request headers from $_SERVER for SAPIs where
+	 * getallheaders() isn't available (e.g. some CGI/FastCGI setups).
+	 *
+	 * @return array<string,string>
+	 */
+	private function get_headers_from_server() {
+		$headers = array();
+		foreach ( $_SERVER as $key => $value ) {
+			if ( 0 === strpos( $key, 'HTTP_' ) ) {
+				$headers[ str_replace( '_', '-', substr( $key, 5 ) ) ] = $value;
+			} elseif ( in_array( $key, array( 'CONTENT_TYPE', 'CONTENT_LENGTH', 'CONTENT_MD5' ), true ) ) {
+				$headers[ str_replace( '_', '-', $key ) ] = $value;
+			}
+		}
+		return $headers;
+	}
+
+	/**
+	 * Forward response headers to the browser, stripping hop-by-hop ones.
+	 *
+	 * @param  \Requests_Utility_CaseInsensitiveDictionary|array $headers Response headers object.
+	 * @return void
+	 */
+	private function send_response_headers( $headers ) {
+		foreach ( $headers as $key => $value ) {
+			$lower = strtolower( $key );
+			if ( in_array( $lower, self::$hop_by_hop_response, true )
+				|| in_array( $lower, self::$stripped_security_response, true ) ) {
+				continue;
+			}
+			// Remove any header WordPress (or nginx) already set under this
+			// name so we don't emit duplicates.
+			header_remove( $key );
+			foreach ( (array) $value as $v ) {
+				if ( 'set-cookie' === $lower ) {
+					$v = $this->strip_cookie_domain( $v );
+				}
+				// false = append rather than replace so that multi-value
+				// headers such as Set-Cookie are forwarded in full.
+				header( $key . ': ' . $v, false );
+			}
+		}
+	}
+
+	/**
+	 * Strip the Domain= attribute from a Set-Cookie header value.
+	 *
+	 * @param  string $cookie Raw Set-Cookie header value.
+	 * @return string
+	 */
+	private function strip_cookie_domain( $cookie ) {
+		return preg_replace( '/;\s*Domain=[^;]*/i', '', $cookie );
+	}
+}


### PR DESCRIPTION
# PRI-772: WP same origin

## Summary

Adds a native **Same-Origin Proxy** so the Google Tag Manager loader (and all sGTM
traffic) is served from Stape **through the site's own WordPress domain** instead of a
third-party host. Requests to a merchant-chosen path (e.g. `/gtm/`) are transparently
forwarded to the Stape sGTM container, making tag delivery first-party without any
DNS, CDN, or reverse-proxy configuration.

Everything is opt-in and defaults are unchanged: with the toggle off the plugin
behaves exactly as before.

## New functionality

- **General tab card** — a "Same-origin proxy (Beta)" toggle plus two fields:
  - **Proxy path** — the first-party path traffic is routed through (must start with `/`).
  - **Container API key** — the Stape container API key (not the container identifier),
    which encodes the upstream endpoint.
- **Test connection** button — enabled only once the path has been saved; it issues a
  browser-side request with a random `test-uid` and verifies the proxy echoes it back,
  confirming the round-trip works before going live.
- When enabled, the plugin automatically:
  - Points the GTM container URL and identifier at the first-party path.
  - Registers the custom loader with Stape using the same-origin host/path.
  - Rewrites `.js` loader references to `.load` so they hit the proxy rather than the
    static file server.
  - Disables the cookie keeper (superseded by first-party delivery).

## Main technical highlights

- **Native WordPress rewrite, no `REQUEST_URI` parsing** —
  `class-gtm-server-side-same-origin-proxy.php` registers an `add_rewrite_rule()` with
  dedicated query vars and handles the request on `template_redirect`. Rewrite rules are
  flushed on activation/deactivation and via a **debounced `shutdown` flush** whenever a
  relevant option changes, keeping the stored rules and `.htaccess` in sync.
- **Faithful transparent proxy** via `wp_remote_request()`:
  - Method validated against an allowlist to prevent header injection; request body
    forwarded only for body-bearing methods.
  - **Hop-by-hop headers stripped** in both directions, plus removal of restrictive
    upstream security headers (`X-Frame-Options`, `X-Content-Type-Options`,
    `Referrer-Policy`) that would otherwise break embedding.
  - `Set-Cookie` `Domain=` attribute stripped so cookies bind to the first-party host.
  - Output buffers drained before echoing the body to avoid double gzip encoding.
  - `getallheaders()` with a `$_SERVER` fallback for CGI/FastCGI SAPIs.
- **Centralized API-key parsing** — `parse_stape_api_key()` in the helpers turns the
  colon-separated key (`a0:a1:a2[:tld]`) into the upstream endpoint
  `https://a1.a0.stape.{tld}`. The data-manager ingest handler was refactored to reuse
  this single parser instead of its own inline `explode()`.
- **Mode-aware custom loader** — `class-gtm-server-side-customer-loader-handler.php` was
  refactored into `get_request_context()` with separate default vs. same-origin builders,
  and the options watcher now regenerates the loader whenever any same-origin setting
  changes.
- **Path validation** — `sanitize_same_origin_path()` rejects paths without a leading
  slash, surfaces a settings error, and preserves the previously saved value.