### PR TITLE
v2.3.3: Proxy status check

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Tested up to:** 7.0.0
 
-**Stable tag:** 2.3.2
+**Stable tag:** 2.3.3
 
 **License:** GPLv2 or later
 
@@ -86,6 +86,10 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.3.3
+- Added a proxy status check that confirms the `server_container_url` to use in web GTM once the same-origin proxy path is verified.
+- Same-origin settings are now validated before saving: the proxy path must start with `/` and the container API key must match the expected format.
 
 ## 2.3.2
 - Extended item_brand sources in Advanced parameters: all product taxonomies are now selectable.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
 Tested up to: 7.0.0
-Stable tag: 2.3.2
+Stable tag: 2.3.3
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -68,6 +68,10 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.3.3 =
+* Added a proxy status check that confirms the server_container_url to use in web GTM once the same-origin proxy path is verified.
+* Same-origin settings are now validated before saving: the proxy path must start with "/" and the container API key must match the expected format.
 
 = 2.3.2 =
 * Extended item_brand sources in Advanced parameters: all product taxonomies are now selectable.

--- a/assets/css/admin-style.css
+++ b/assets/css/admin-style.css
@@ -168,6 +168,146 @@
 	display: table-row;
 }
 
+/* Validation messages sit on their own line, between control and description. */
+.gtm-so-card label.error {
+	display: block;
+	margin-top: 4px;
+	padding-left: 0;
+}
+
+/* Confirmation notice shown once the proxy path is verified as reachable. */
+.gtm-so-status {
+	margin: 12px 0 4px;
+}
+
+.gtm-so-checking {
+	display: flex;
+	align-items: center;
+	gap: 4px;
+	margin: 0;
+	color: #50575e;
+}
+
+.gtm-so-checking .spinner {
+	float: none;
+	margin: 0;
+}
+
+.gtm-so-notice {
+	max-width: 860px;
+	margin: 0;
+	padding: 14px 18px;
+	border: 1px solid #c5d9ef;
+	border-radius: 8px;
+	background: #f6faff;
+	color: #1d2327;
+	line-height: 1.7;
+}
+
+.gtm-so-notice code {
+	padding: 0;
+	background: none;
+	color: #2271b1;
+	font-weight: 600;
+}
+
+/*
+ * Reusable inline copy-to-clipboard control.
+ *
+ * Wrap any element in `.gtm-copy` and add a `.copy-button` beside it. Pairs
+ * with core's bundled `clipboard` script, which the admin JS wires up.
+ */
+.gtm-copy {
+	display: inline-flex;
+	align-items: center;
+	gap: 4px;
+}
+
+.gtm-copy .copy-button {
+	position: relative;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 24px;
+	height: 24px;
+	padding: 0;
+	border: 0;
+	border-radius: 3px;
+	background: none;
+	color: #787c82;
+	text-decoration: none;
+	cursor: pointer;
+	transition: color 200ms ease, background-color 200ms ease;
+}
+
+.gtm-copy .copy-button:hover {
+	background: #f0f0f1;
+	color: #2271b1;
+}
+
+/* Keyboard users still get a ring; clicking the button does not leave one. */
+.gtm-copy .copy-button:focus {
+	outline: none;
+	box-shadow: none;
+}
+
+.gtm-copy .copy-button:focus-visible {
+	color: #2271b1;
+	outline: 2px solid transparent;
+	box-shadow: 0 0 0 2px #2271b1;
+}
+
+.gtm-copy .copy-button .dashicons {
+	width: 16px;
+	height: 16px;
+	font-size: 16px;
+	line-height: 1;
+}
+
+/* Confirmation swaps the glyph in place, so nothing around it reflows. */
+.gtm-copy .copy-button.is-copied {
+	color: #007017;
+}
+
+.gtm-copy .copy-button.is-copied .dashicons::before {
+	content: "\f147";
+}
+
+.gtm-copy .copy-tooltip {
+	position: absolute;
+	bottom: 100%;
+	left: 50%;
+	z-index: 1;
+	margin-bottom: 6px;
+	padding: 3px 7px;
+	border-radius: 3px;
+	background: #1d2327;
+	color: #fff;
+	font-size: 11px;
+	line-height: 1.5;
+	white-space: nowrap;
+	transform: translateX( -50% );
+	opacity: 0;
+	visibility: hidden;
+	pointer-events: none;
+	transition: opacity 200ms ease, visibility 200ms ease;
+}
+
+.gtm-copy .copy-tooltip::after {
+	position: absolute;
+	top: 100%;
+	left: 50%;
+	margin-left: -4px;
+	border: 4px solid transparent;
+	border-top-color: #1d2327;
+	content: "";
+}
+
+.gtm-copy .copy-button.is-copied .copy-tooltip {
+	opacity: 1;
+	visibility: visible;
+}
+
 /* Container URL / identifier / Cookie Keeper are hidden while the proxy is on. */
 #gtm-server-side-admin-settings:has( #gtm_server_side_same_origin_enable:checked ) .js-gtm-server-side-alternative-scenario {
 	display: none;

--- a/assets/js/admin-javascript.js
+++ b/assets/js/admin-javascript.js
@@ -23,11 +23,22 @@ jQuery( document ).ready(
 					},
 					gtm_server_side_gtm_exclude_roles: {
 						gtmExcludeRoles: true
+					},
+					gtm_server_side_same_origin_path: {
+						sameOriginPath: true
+					},
+					gtm_server_side_same_origin_api_key: {
+						sameOriginApiKey: true
 					}
 				},
 				errorPlacement: function(error, element) {
+					const sameOriginFields = [ 'gtm_server_side_same_origin_path', 'gtm_server_side_same_origin_api_key' ];
+
 					if ( element.attr( 'name' ) === 'gtm_server_side_gtm_exclude_roles' ) {
 						jQuery( '.js-gtm-server-side-gtm-exclude-roles-message' ).empty().append( error );
+					} else if ( sameOriginFields.indexOf( element.attr( 'name' ) ) !== -1 ) {
+						// Own line under the control, above the field description.
+						error.insertAfter( element.closest( 'td' ).children( 'br' ).first() );
 					} else {
 						error.insertAfter( element );
 					}
@@ -83,6 +94,28 @@ jQuery( document ).ready(
 			},
 			'Select at least one role'
 		);
+		jQuery.validator.addMethod(
+			'sameOriginPath',
+			function( value, element ) {
+				if ( ! jQuery( '#gtm_server_side_same_origin_enable' ).is( ':checked' ) ) {
+					return true;
+				}
+
+				return /^\/+[^\/\s]\S*$/.test( value.trim() );
+			},
+			'Enter the path requests are proxied through, starting with "/" (e.g. /gtm)'
+		);
+		jQuery.validator.addMethod(
+			'sameOriginApiKey',
+			function( value, element ) {
+				if ( ! jQuery( '#gtm_server_side_same_origin_enable' ).is( ':checked' ) ) {
+					return true;
+				}
+
+				return /^[A-Za-z0-9.-]+:[A-Za-z0-9.-]+:[^:\s]+(:[A-Za-z0-9.-]+)?$/.test( value.trim() );
+			},
+			'Container API key must be colon-separated, as copied from Stape container settings'
+		);
 
 		// Tab "General".
 		pluginGtmServerSide.changeContainerId();
@@ -104,6 +137,7 @@ jQuery( document ).ready(
 
 		if ( jQuery( '#gtm_server_side_same_origin_enable' ).length ) {
 			pluginGtmServerSide.initSameOrigin();
+			pluginGtmServerSide.testSameOrigin( true );
 			jQuery( '#gtm_server_side_same_origin_enable' ).on(
 				'click',
 				function() {
@@ -122,10 +156,12 @@ jQuery( document ).ready(
 				'.js-gtm-server-side-test-same-origin',
 				function( e ) {
 					e.preventDefault();
-					pluginGtmServerSide.testSameOrigin();
+					pluginGtmServerSide.testSameOrigin( false );
 				}
 			);
 		}
+
+		pluginGtmServerSide.initCopyToClipboard();
 
 		pluginGtmServerSide.changeExcludeGtmUserRoles();
 		jQuery( '.js-gtm_server_side_gtm_exclude_roles' ).on(
@@ -550,31 +586,106 @@ const pluginGtmServerSide = {
 	 * Test the same-origin proxy connection by sending a browser-side GET
 	 * request with a random uid and verifying the plain-text echo response.
 	 *
+	 * The result resolves the proxy status block (spinner -> confirmation
+	 * notice, or removed on failure). When triggered by the "Test connection"
+	 * button it additionally reports next to that button.
+	 *
+	 * @param {boolean} isAuto Run as the automatic status check on page load.
 	 * @return {void}
 	 */
-	testSameOrigin: function() {
-		if ( 'undefined' === typeof varGtmServerSide || ! varGtmServerSide.same_origin_url ) {
+	testSameOrigin: function( isAuto ) {
+		const $status  = jQuery( '.js-gtm-so-status' );
+		const $message = jQuery( '.js-gtm-server-side-same-origin-message' );
+
+		if ( isAuto && ! $status.length ) {
 			return;
 		}
 
-		const uid      = Date.now().toString( 36 );
-		const $message = jQuery( '.js-gtm-server-side-same-origin-message' );
-		$message.html( '<i>Testing&hellip;</i>' );
+		if ( 'undefined' === typeof varGtmServerSide || ! varGtmServerSide.same_origin_url ) {
+			$status.remove();
+			return;
+		}
+
+		const uid = Date.now().toString( 36 );
+
+		const done = function( isOk, message ) {
+			if ( isOk ) {
+				$status.find( '.js-gtm-so-checking' ).remove();
+				$status.find( '.js-gtm-so-notice' ).prop( 'hidden', false );
+			} else {
+				$status.remove();
+			}
+
+			if ( ! isAuto ) {
+				$message.html( message );
+			}
+		};
+
+		if ( ! isAuto ) {
+			$message.html( '<i>Testing&hellip;</i>' );
+		}
 
 		jQuery.ajax( {
 			url:     varGtmServerSide.same_origin_url,
 			method:  'GET',
 			data:    { 'test-uid': uid },
 			success: function( response ) {
-				if ( String( response ).trim() === uid ) {
-					$message.html( '<span class="success">Connection successful!</span>' );
-				} else {
-					$message.html( '<span class="error">Connection failed: unexpected response.</span>' );
-				}
+				const isOk = String( response ).trim() === uid;
+				done(
+					isOk,
+					isOk
+						? '<span class="success">Connection successful!</span>'
+						: '<span class="error">Connection failed: unexpected response.</span>'
+				);
 			},
 			error: function() {
-				$message.html( '<span class="error">Connection failed.</span>' );
+				done( false, '<span class="error">Connection failed.</span>' );
 			}
 		} );
+	},
+
+	/**
+	 * Wire every `.gtm-copy` control on the page, using the clipboard.js
+	 * library bundled with WordPress.
+	 *
+	 * The selector form of ClipboardJS delegates from the document, so controls
+	 * revealed later — such as the proxy URL, which appears once the status
+	 * check resolves — keep working without re-initialising.
+	 *
+	 * @return {void}
+	 */
+	initCopyToClipboard: function() {
+		if ( 'undefined' === typeof ClipboardJS ) {
+			return;
+		}
+
+		const clipboard = new ClipboardJS(
+			'.js-gtm-copy',
+			{
+				text: function( trigger ) {
+					return jQuery( trigger ).closest( '.gtm-copy' ).find( 'code' ).first().text();
+				}
+			}
+		);
+
+		clipboard.on(
+			'success',
+			function( event ) {
+				const $button = jQuery( event.trigger );
+				$button.addClass( 'is-copied' );
+				setTimeout(
+					function() {
+						$button.removeClass( 'is-copied' );
+					},
+					2000
+				);
+
+				if ( window.wp && window.wp.a11y ) {
+					window.wp.a11y.speak( 'Copied to clipboard.' );
+				}
+
+				event.clearSelection();
+			}
+		);
 	},
 };

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.3.2
+ * Version:           2.3.3
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+

--- a/includes/class-gtm-server-side-admin-assets.php
+++ b/includes/class-gtm-server-side-admin-assets.php
@@ -33,7 +33,7 @@ class GTM_Server_Side_Admin_Assets {
 		wp_register_script( 'vendor-jquery-validation', GTM_SERVER_SIDE_URL . 'assets/vendors/jquery-validation/jquery.validate.min.js', array( 'jquery' ), get_gtm_server_side_version(), true );
 
 		wp_register_style( 'gtm-server-side-admin', GTM_SERVER_SIDE_URL . 'assets/css/admin-style.css', null, get_gtm_server_side_version() );
-		wp_register_script( 'gtm-server-side-admin', GTM_SERVER_SIDE_URL . 'assets/js/admin-javascript.js', array( 'vendor-jquery-validation' ), get_gtm_server_side_version(), true );
+		wp_register_script( 'gtm-server-side-admin', GTM_SERVER_SIDE_URL . 'assets/js/admin-javascript.js', array( 'vendor-jquery-validation', 'clipboard', 'wp-a11y' ), get_gtm_server_side_version(), true );
 
 		wp_localize_script(
 			'gtm-server-side-admin',

--- a/includes/class-gtm-server-side-admin-settings-general.php
+++ b/includes/class-gtm-server-side-admin-settings-general.php
@@ -364,6 +364,42 @@ class GTM_Server_Side_Admin_Settings_General {
 							<span class="js-gtm-server-side-same-origin-message"></span>
 							<br>
 							<?php esc_html_e( 'The path on this domain that requests are proxied through. Must start with a slash. Save settings before testing.', 'gtm-server-side' ); ?>
+							<?php if ( GTM_Server_Side_Helpers::is_same_origin_path_active() ) : ?>
+							<div class="gtm-so-status js-gtm-so-status" aria-live="polite">
+								<p class="gtm-so-checking js-gtm-so-checking">
+									<span class="spinner is-active"></span>
+									<?php esc_html_e( 'Checking proxy status…', 'gtm-server-side' ); ?>
+								</p>
+								<div class="gtm-so-notice js-gtm-so-notice" hidden>
+									<?php
+									$same_origin_url_html = sprintf(
+										'<span class="gtm-copy"><code>%1$s</code><button type="button" class="copy-button js-gtm-copy" aria-label="%2$s"><span class="dashicons dashicons-admin-page" aria-hidden="true"></span><span class="copy-tooltip" aria-hidden="true">%3$s</span></button></span>',
+										esc_html( GTM_Server_Side_Helpers::get_same_origin_url() ),
+										esc_attr__( 'Copy URL to clipboard', 'gtm-server-side' ),
+										esc_html__( 'Copied!', 'gtm-server-side' )
+									);
+									echo wp_kses(
+										sprintf(
+											__( '%s is now configured as reverse proxy for your Stape container. You can now use it as <code>server_container_url</code> in your web GTM.', 'gtm-server-side' ),
+											$same_origin_url_html
+										),
+										array(
+											'code'   => array(),
+											'span'   => array(
+												'class'       => array(),
+												'aria-hidden' => array(),
+											),
+											'button' => array(
+												'type'       => array(),
+												'class'      => array(),
+												'aria-label' => array(),
+											),
+										)
+									);
+									?>
+								</div>
+							</div>
+							<?php endif; ?>
 						</td>
 					</tr>
 					<tr class="gtm-server-side-same-origin-field">

--- a/includes/class-gtm-server-side-helpers.php
+++ b/includes/class-gtm-server-side-helpers.php
@@ -177,21 +177,15 @@ class GTM_Server_Side_Helpers {
 	 * @return array|null  Indexed array [0..3] or null on parse failure.
 	 */
 	public static function parse_stape_api_key( $key ) {
-		$parts = explode( ':', trim( (string) $key ) );
-		if (
-			count( $parts ) < 3 ||
-			'' === $parts[0] ||
-			'' === $parts[1] ||
-			'' === $parts[2]
-		) {
+		if ( ! preg_match( '/^([A-Za-z0-9.-]+):([A-Za-z0-9.-]+):([^:\s]+)(?::([A-Za-z0-9.-]+))?$/', trim( (string) $key ), $matches ) ) {
 			return null;
 		}
 
 		return array(
-			0 => $parts[0],
-			1 => $parts[1],
-			2 => $parts[2],
-			3 => ( isset( $parts[3] ) && '' !== $parts[3] ) ? $parts[3] : 'io',
+			0 => $matches[1],
+			1 => $matches[2],
+			2 => $matches[3],
+			3 => isset( $matches[4] ) ? $matches[4] : 'io',
 		);
 	}
 
@@ -246,6 +240,20 @@ class GTM_Server_Side_Helpers {
 	}
 
 	/**
+	 * Whether the same-origin proxy path is live on this site.
+	 *
+	 * Mirrors the conditions under which the rewrite rule is registered, so it
+	 * answers the same question the admin status check does: can this path be
+	 * reached? The API key is deliberately not considered — it governs whether
+	 * requests can be forwarded upstream, not whether the path resolves.
+	 *
+	 * @return bool
+	 */
+	public static function is_same_origin_path_active() {
+		return self::is_enable_same_origin() && '' !== self::get_raw_same_origin_path();
+	}
+
+	/**
 	 * Sanitize a same-origin path value.
 	 * Trims whitespace; the trailing slash is preserved if the user included it.
 	 * Rejects values that don't start with '/' and keeps the previously saved
@@ -261,18 +269,18 @@ class GTM_Server_Side_Helpers {
 			return '';
 		}
 
-		if ( '/' !== $value[0] ) {
-			add_settings_error(
-				GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH,
-				'gtm_server_side_same_origin_path_invalid',
-				__( 'Same-origin proxy path must start with "/" (e.g. /gtm/). The previous value was kept.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN )
-			);
-			return self::get_raw_same_origin_path();
-		}
-
 		// Drop any query/fragment if the user pasted it, and normalize duplicate slashes.
 		$value = preg_replace( '/[?#].*$/', '', $value );
 		$value = preg_replace( '#/+#', '/', $value );
+
+		if ( ! preg_match( '#^/[^/\s]\S*$#', $value ) ) {
+			add_settings_error(
+				GTM_SERVER_SIDE_FIELD_SAME_ORIGIN_PATH,
+				'gtm_server_side_same_origin_path_invalid',
+				__( 'Same-origin proxy path must start with "/" and contain a path segment (e.g. /gtm). The previous value was kept.', GTM_SERVER_SIDE_TRANSLATION_DOMAIN )
+			);
+			return self::get_raw_same_origin_path();
+		}
 
 		return $value;
 	}

--- a/includes/class-gtm-server-side-same-origin-proxy.php
+++ b/includes/class-gtm-server-side-same-origin-proxy.php
@@ -121,21 +121,13 @@ class GTM_Server_Side_Same_Origin_Proxy {
 	 * @return void
 	 */
 	public function register_rewrite_rule() {
-		if ( ! GTM_Server_Side_Helpers::is_enable_same_origin() ) {
-			return;
-		}
-
-		$raw_path = GTM_Server_Side_Helpers::get_raw_same_origin_path();
-		if ( '' === $raw_path ) {
+		if ( ! GTM_Server_Side_Helpers::is_same_origin_path_active() ) {
 			return;
 		}
 
 		// Trim slashes so the regex anchor works correctly regardless of
 		// whether the stored path has a leading/trailing slash.
-		$path = trim( $raw_path, '/' );
-		if ( '' === $path ) {
-			return;
-		}
+		$path = trim( GTM_Server_Side_Helpers::get_raw_same_origin_path(), '/' );
 
 		add_rewrite_rule(
 			'^' . preg_quote( $path, '/' ) . '(/.*)?$',
@@ -241,6 +233,7 @@ class GTM_Server_Side_Same_Origin_Proxy {
 		if ( '' !== $test_uid ) {
 			header( 'Content-Type: text/plain; charset=utf-8' );
 			header( 'Cache-Control: no-store' );
+			header( 'X-Content-Type-Options: nosniff' );
 			echo esc_html( $test_uid );
 			exit;
 		}


### PR DESCRIPTION
# Proxy status check (v2.3.3)

Once the same-origin proxy path is saved, the settings page verifies that the path is actually reachable and confirms the URL to use as `server_container_url` in web GTM. The URL comes with a click-to-copy control.

## How it works

On page load the browser requests the proxy path with a random `test-uid` and checks that the response echoes it back. This is the same request the "Test connection" button makes, so both paths share one code path. A spinner shows while the check runs; on success it is replaced by the confirmation notice, and on failure the block is removed so nothing misleading is left on screen.

The check runs in the browser rather than server-side on purpose. A PHP loopback request to the site's own URL fails on plenty of hosts — WordPress ships a dedicated Site Health test for exactly that — so a server-side probe would have reported failures that don't exist for real visitors.

The block only renders when the proxy is enabled and a path is saved, mirroring the conditions under which the rewrite rule is registered. The API key is not part of that gate: it governs whether requests can be forwarded upstream, not whether the path resolves.

## Settings validation

Saving is blocked while the proxy is enabled but the path is missing or the container API key is malformed, so the status check no longer runs against a configuration that cannot work. Both rules hang off the jQuery Validate setup the settings form already uses; the API key rule mirrors `parse_stape_api_key()` so the browser and PHP agree on what a well-formed key looks like.

This is client-side only. A direct POST still stores whatever it is given, which is acceptable because the page is `manage_options`-only, and because the proxy already handles bad settings on its own: 404 when they are incomplete, 502 when the key will not parse. Moving the constraint into the `register_setting()` sanitise callbacks is the change to make if it ever needs to actually hold.

## Notes

- The copy control is a reusable `.gtm-copy` component built on the `clipboard` script bundled with WordPress, so no new library ships with the plugin.
- The `test-uid` response is plain text, `no-store` and `nosniff`, and echoes only sanitised, escaped input. It never reaches upstream.
- Adds two script dependencies, `clipboard` and `wp-a11y`, both from core.