### PR TITLE
v2.3.5: Same origin fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Tested up to:** 7.0.0
 
-**Stable tag:** 2.3.4
+**Stable tag:** 2.3.5
 
 **License:** GPLv2 or later
 
@@ -86,6 +86,11 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.3.5
+- Fixed the same-origin loader rewrite so that only the proxied loader URL is changed from `.js` to `.load`, leaving the `gtm.js` bootstrap event name and third-party URLs untouched.
+- The `.js` to `.load` rewrite is now applied to every generated loader snippet, including the ones refreshed by cron.
+- Fixed same-origin proxy responses that set more than one cookie: repeated `Set-Cookie` headers are no longer merged into a single malformed header.
 
 ## 2.3.4
 - Fixed a "Cannot modify header information" warning caused by the cookie keeper running on WP-Cron and WP-CLI requests.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
 Tested up to: 7.0.0
-Stable tag: 2.3.4
+Stable tag: 2.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -68,6 +68,11 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.3.5 =
+* Fixed the same-origin loader rewrite so that only the proxied loader URL is changed from ".js" to ".load", leaving the gtm.js bootstrap event name and third-party URLs untouched.
+* The ".js" to ".load" rewrite is now applied to every generated loader snippet, including the ones refreshed by cron.
+* Fixed same-origin proxy responses that set more than one cookie: repeated Set-Cookie headers are no longer merged into a single malformed header.
 
 = 2.3.4 =
 * Fixed a "Cannot modify header information" warning caused by the cookie keeper running on WP-Cron and WP-CLI requests.

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.3.4
+ * Version:           2.3.5
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+

--- a/includes/class-gtm-server-side-customer-loader-handler.php
+++ b/includes/class-gtm-server-side-customer-loader-handler.php
@@ -18,7 +18,7 @@ class GTM_Server_Side_Customer_Loader_Handler {
 	/**
 	 * Send data.
 	 *
-	 * @return mixed
+	 * @return array|WP_Error
 	 */
 	public function send_data() {
 		$request_context = $this->get_request_context();
@@ -199,7 +199,7 @@ class GTM_Server_Side_Customer_Loader_Handler {
 	 * @param array $response Response.
 	 * @param array $request  Original request.
 	 *
-	 * @return mixed
+	 * @return array|WP_Error
 	 */
 	private function parse_response( $response, $request ) {
 		$status_code = (int) wp_remote_retrieve_response_code( $response );
@@ -219,6 +219,55 @@ class GTM_Server_Side_Customer_Loader_Handler {
 
 		$decoded = json_decode( $raw_body, true );
 
-		return ( json_last_error() === JSON_ERROR_NONE ) ? $decoded : $raw_body;
+		if ( JSON_ERROR_NONE !== json_last_error() || ! is_array( $decoded ) ) {
+			return new WP_Error(
+				'stape_api_invalid_json',
+				'Stape API returned a response that could not be decoded.',
+				array(
+					'status_code' => $status_code,
+					'body'        => $raw_body,
+					'request'     => $request,
+				)
+			);
+		}
+
+		if ( ! empty( $decoded['body']['jsCode'] ) && GTM_Server_Side_Helpers::has_same_origin_settings() ) {
+			$decoded['body']['jsCode'] = $this->rewrite_loader_extension( (string) $decoded['body']['jsCode'] );
+		}
+
+		return $decoded;
+	}
+
+	/**
+	 * Rewrite the loader extension from ".js" to ".load".
+	 *
+	 * Web servers often serve ".js" paths as static files, so the same-origin loader is
+	 * requested with the ".load" extension and mapped back by the proxy handler.
+	 *
+	 * The match is anchored to a URL whose path begins with the same value that was
+	 * sent to the API as `sameOriginPath`, so it cannot touch the GTM bootstrap event
+	 * name ("gtm.js") or third-party URLs that merely contain the proxy path further
+	 * down their own path. The path is taken from get_same_origin_url() rather than the
+	 * raw setting because it must include the WordPress home path on sub-directory
+	 * installs (e.g. "/wp/gtm"), which is what the returned snippet contains.
+	 *
+	 * @param  string $js_code Loader snippet returned by the API.
+	 * @return string
+	 */
+	private function rewrite_loader_extension( $js_code ) {
+		$path = (string) wp_parse_url( GTM_Server_Side_Helpers::get_same_origin_url(), PHP_URL_PATH );
+		$path = rtrim( $path, '/' );
+
+		if ( '' === $path ) {
+			return $js_code;
+		}
+
+		$path = '/' . ltrim( $path, '/' );
+
+		$pattern = '#((?:https?:)?//[^/"\'\s?]+'
+			. preg_quote( $path, '#' )
+			. '(?:/[A-Za-z0-9._~-]+)+)\.js(?=[?"\'])#i';
+
+		return (string) preg_replace( $pattern, '$1.load', $js_code );
 	}
 }

--- a/includes/class-gtm-server-side-customer-loader-options-watcher.php
+++ b/includes/class-gtm-server-side-customer-loader-options-watcher.php
@@ -64,14 +64,7 @@ class GTM_Server_Side_Customer_Loader_Options_Watcher {
 			! empty( $result['body'] ) &&
 			! empty( $result['body']['jsCode'] )
 		) {
-			$js_code = (string) $result['body']['jsCode'];
-
-			if ( GTM_Server_Side_Helpers::has_same_origin_settings() ) {
-				// jsCode is generated for the same-origin context, so every ".js" reference in it must land on the proxy as ".load" to avoid static file server.
-				$js_code = preg_replace( '/\.js(?=(\?|"|\'))/', '.load', $js_code );
-			}
-
-			update_option( GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API, $js_code );
+			update_option( GTM_SERVER_SIDE_GTM_CUSTOM_LOADER_FROM_API, (string) $result['body']['jsCode'] );
 			return;
 		}
 

--- a/includes/class-gtm-server-side-same-origin-proxy.php
+++ b/includes/class-gtm-server-side-same-origin-proxy.php
@@ -373,16 +373,21 @@ class GTM_Server_Side_Same_Origin_Proxy {
 	 * @return void
 	 */
 	private function send_response_headers( $headers ) {
+		$has_get_values = is_object( $headers ) && method_exists( $headers, 'getValues' );
+
 		foreach ( $headers as $key => $value ) {
 			$lower = strtolower( $key );
 			if ( in_array( $lower, self::$hop_by_hop_response, true )
 				|| in_array( $lower, self::$stripped_security_response, true ) ) {
 				continue;
 			}
+
+			$values = $has_get_values ? (array) $headers->getValues( $key ) : (array) $value;
+
 			// Remove any header WordPress (or nginx) already set under this
 			// name so we don't emit duplicates.
 			header_remove( $key );
-			foreach ( (array) $value as $v ) {
+			foreach ( $values as $v ) {
 				if ( 'set-cookie' === $lower ) {
 					$v = $this->strip_cookie_domain( $v );
 				}


### PR DESCRIPTION
# Same-origin: fix loader rewrite and multi-cookie proxy responses (2.3.5)

## Summary

Three same-origin fixes, aligned with the behaviour already shipped in the Magento 2 module.

## Changes

### 1. Anchor the `.js` → `.load` rewrite to the proxy path

The rewrite used a blanket `/\.js(?=(\?|"|\'))/`, which also matched the GTM bootstrap event name and produced `event:'gtm.load'` in the rendered snippet. The pattern is now anchored to a URL whose first path segment is the configured proxy path, so only the proxied loader URL is rewritten.

### 2. Apply the rewrite on every snippet generation

The rewrite lived in the options watcher, so the cron refresh (`GTM_Server_Side_Customer_Loader_Cron`) stored the raw `jsCode` and silently reverted the loader URL to `.js`, breaking same-origin until the settings were saved again. It now runs in `GTM_Server_Side_Customer_Loader_Handler::parse_response()`, the single point both callers go through.

### 3. Stop merging repeated `Set-Cookie` headers

`send_response_headers()` iterated the `Requests\Response\Headers` object, which flattens repeated headers into one comma-joined string. With two or more upstream cookies they were emitted as a single malformed `Set-Cookie`, and `strip_cookie_domain()` ran past the comma and consumed the next cookie's `name=value`. The unflattened list is now read via `getValues()` and each cookie is sent as its own header.

## Notes

Existing installs keep the previously cached snippet in the `gtm_server_side_gtm_custom_loader_from_api` option until the same-origin settings are saved again or the cron refresh runs.
