### PR TITLE
v2.3.6: Fixed a JavaScript error ("item is not iterable")

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,9 @@
 
 **Requires at least:** 5.2.0
 
-**Tested up to:** 7.0.0
+**Tested up to:** 7.1.0
 
-**Stable tag:** 2.3.5
+**Stable tag:** 2.3.6
 
 **License:** GPLv2 or later
 
@@ -86,6 +86,10 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.3.6
+- Fixed a JavaScript error (`item is not iterable`) that broke the `add_to_cart` data layer event when adding a grouped product to the cart.
+- Tested up to WordPress 7.1.0
 
 ## 2.3.5
 - Fixed the same-origin loader rewrite so that only the proxied loader URL is changed from `.js` to `.load`, leaving the `gtm.js` bootstrap event name and third-party URLs untouched.

--- a/README.txt
+++ b/README.txt
@@ -2,8 +2,8 @@
 Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
-Tested up to: 7.0.0
-Stable tag: 2.3.5
+Tested up to: 7.1.0
+Stable tag: 2.3.6
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -68,6 +68,10 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.3.6 =
+* Fixed a JavaScript error ("item is not iterable") that broke the add_to_cart data layer event when adding a grouped product to the cart.
+* Tested up to WordPress 7.1.0
 
 = 2.3.5 =
 * Fixed the same-origin loader rewrite so that only the proxied loader URL is changed from ".js" to ".load", leaving the gtm.js bootstrap event name and third-party URLs untouched.

--- a/assets/js/javascript.js
+++ b/assets/js/javascript.js
@@ -373,26 +373,28 @@ var pluginGtmServerSide = {
 	/**
 	 * Push to dataLayer.
 	 *
-	 * @param object originalItem List items.
+	 * @param object|array originalItem Single item or list of items.
 	 * @param string event Event name.
 	 * @param string pagetype Page type name.
 	 * @param object customEcommerce Ecommerce data.
 	 */
 	_pushToDataLayer: function ( originalItem, event, pagetype, customEcommerce = {} ) {
-		item = Object.assign( {}, originalItem );
-		if ( item.item_id ) {
-			item = [ item ];
-		}
+		var originalItems = Array.isArray( originalItem ) ? originalItem : [ originalItem ];
 
 		var items = [];
 		var value = 0;
 		var index = 1;
-		for ( var item_loop of item ) {
+		for ( var original of originalItems ) {
+			var item_loop      = Object.assign( {}, original );
 			item_loop.index    = index++;
 			item_loop.quantity = item_loop.quantity ? parseInt( item_loop.quantity, 10 ) : 1;
 			item_loop          = this.filterItemPrice( item_loop );
 			value              = parseFloat( value + ( item_loop.price * item_loop.quantity ) );
 			items.push( item_loop );
+		}
+
+		if ( ! items.length ) {
+			return;
 		}
 
 		let eventDataEcommerce = {

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.3.5
+ * Version:           2.3.6
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+


### PR DESCRIPTION
# Data Layer: fix "item is not iterable" on grouped products (2.3.6)

## Summary

Resolves #65. Adding a grouped product to the cart threw `Uncaught TypeError: item is not iterable` and no `add_to_cart` event reached the data layer.

## Changes

`pushGroupProduct()` passes an array of items, but `_pushToDataLayer()` normalised it with `item = Object.assign( {}, originalItem )`, turning the array into `{ 0: {…}, 1: {…} }`. That object has no `item_id`, so it was never re-wrapped in an array and the following `for ( … of item )` threw.

- Normalise with `Array.isArray( originalItem ) ? originalItem : [ originalItem ]` instead of relying on `item_id`.
- Clone each item inside the loop, so list items are no longer mutated in place. Removes the implicit global `item`.
- Return early when the list is empty (grouped product submitted with no quantities), instead of throwing.
