### PR TITLE
v2.3.7: Same origin service worker fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 **Tested up to:** 7.1.0
 
-**Stable tag:** 2.3.6
+**Stable tag:** 2.3.7
 
 **License:** GPLv2 or later
 
@@ -86,6 +86,9 @@ Yes. Follow this guide: [How to Setup Facebook Conversion API](https://stape.io/
 
 <details>
   <summary>Version 2 changelog</summary>
+
+## 2.3.7
+- Fixed the same-origin service worker returning a 404: the tag container builds its service worker URL at runtime, so the `.js` to `.load` rewrite never reached it and the request was answered by the web server's static file handler before WordPress could proxy it.
 
 ## 2.3.6
 - Fixed a JavaScript error (`item is not iterable`) that broke the `add_to_cart` data layer event when adding a grouped product to the cart.

--- a/README.txt
+++ b/README.txt
@@ -3,7 +3,7 @@ Contributors: gtmserver,bukashk0zzz
 Tags: google tag manager, google tag manager server side, gtm, gtm server side, tag manager, tagmanager, analytics, google, serverside, server-side, gtag
 Requires at least: 5.2.0
 Tested up to: 7.1.0
-Stable tag: 2.3.6
+Stable tag: 2.3.7
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
 
@@ -68,6 +68,9 @@ Yes. <a href="https://stape.io/blog/how-to-set-up-facebook-conversion-api">How t
 4. Menu item in the settings panel.
 
 == Changelog ==
+
+= 2.3.7 =
+* Fixed the same-origin service worker returning a 404: the tag container builds its service worker URL at runtime, so the ".js" to ".load" rewrite never reached it and the request was answered by the web server's static file handler before WordPress could proxy it.
 
 = 2.3.6 =
 * Fixed a JavaScript error ("item is not iterable") that broke the add_to_cart data layer event when adding a grouped product to the cart.

--- a/gtm-server-side.php
+++ b/gtm-server-side.php
@@ -10,7 +10,7 @@
  * Plugin Name:       Stape Conversion Tracking
  * Plugin URI:        https://wordpress.org/plugins/gtm-server-side/
  * Description:       Enhance conversion tracking by implementing server-side tagging using server Google Tag Manager container. Effortlessly configure data layer events in web GTM, send webhooks, set up custom loader, and extend cookie lifetime.
- * Version:           2.3.6
+ * Version:           2.3.7
  * Author:            Stape
  * Author URI:        https://stape.io
  * License:           GPL-2.0+

--- a/includes/class-gtm-server-side-customer-loader-handler.php
+++ b/includes/class-gtm-server-side-customer-loader-handler.php
@@ -247,22 +247,17 @@ class GTM_Server_Side_Customer_Loader_Handler {
 	 * The match is anchored to a URL whose path begins with the same value that was
 	 * sent to the API as `sameOriginPath`, so it cannot touch the GTM bootstrap event
 	 * name ("gtm.js") or third-party URLs that merely contain the proxy path further
-	 * down their own path. The path is taken from get_same_origin_url() rather than the
-	 * raw setting because it must include the WordPress home path on sub-directory
-	 * installs (e.g. "/wp/gtm"), which is what the returned snippet contains.
+	 * down their own path.
 	 *
 	 * @param  string $js_code Loader snippet returned by the API.
 	 * @return string
 	 */
 	private function rewrite_loader_extension( $js_code ) {
-		$path = (string) wp_parse_url( GTM_Server_Side_Helpers::get_same_origin_url(), PHP_URL_PATH );
-		$path = rtrim( $path, '/' );
+		$path = GTM_Server_Side_Helpers::get_same_origin_base_path();
 
 		if ( '' === $path ) {
 			return $js_code;
 		}
-
-		$path = '/' . ltrim( $path, '/' );
 
 		$pattern = '#((?:https?:)?//[^/"\'\s?]+'
 			. preg_quote( $path, '#' )

--- a/includes/class-gtm-server-side-helpers.php
+++ b/includes/class-gtm-server-side-helpers.php
@@ -240,6 +240,26 @@ class GTM_Server_Side_Helpers {
 	}
 
 	/**
+	 * Absolute path prefix the proxy answers on, as it appears in browser URLs.
+	 *
+	 * Derived from get_same_origin_url() rather than the raw setting so that it
+	 * carries the WordPress home path on sub-directory installs (e.g. "/wp/gtm").
+	 * Normalized to a leading slash and no trailing slash so it can be used both
+	 * as a string prefix and as a regex anchor.
+	 *
+	 * @return string  Empty string when no path is configured.
+	 */
+	public static function get_same_origin_base_path() {
+		$path = rtrim( (string) wp_parse_url( self::get_same_origin_url(), PHP_URL_PATH ), '/' );
+
+		if ( '' === $path ) {
+			return '';
+		}
+
+		return '/' . ltrim( $path, '/' );
+	}
+
+	/**
 	 * Whether the same-origin proxy path is live on this site.
 	 *
 	 * Mirrors the conditions under which the rewrite rule is registered, so it

--- a/includes/class-gtm-server-side-tracking-code.php
+++ b/includes/class-gtm-server-side-tracking-code.php
@@ -55,6 +55,7 @@ class GTM_Server_Side_Tracking_Code {
 		}
 
 		if ( GTM_Server_Side_Helpers::has_gtm_custom_loader_from_api() ) {
+			$this->print_same_origin_service_worker_patch();
 			$this->print_gtm_custom_loader_from_api();
 			return;
 		}
@@ -124,6 +125,38 @@ class GTM_Server_Side_Tracking_Code {
 	 */
 	private function print_gtm_consent_loader() {
 		echo '<script>!function(){"use strict";for(var t={window:window,gtmVariable:"dataLayer",onConsentGranted:function(){var t,e,n;t="custom-loader",(t=document.getElementById(t))&&"text/plain"===t.type&&(t.type="text/javascript",n=t.cloneNode(!0),null!=(e=t.parentNode))&&e.replaceChild(n,t)}},e=t.window,n=t.gtmVariable,a=t.onConsentGranted,r=((t=e)[n]||(t[n]=[]),!1),o=t[n],d=function(){r||(r=!0,a())},i=function(t){return!(!t||"consent"!==t[0]||-1===["default","update"].indexOf(t[1])||!(t=t[2])||"object"!=typeof t||"granted"!==t.ad_storage&&"granted"!==t.analytics_storage)},u=o.push,l=(o.push=function(){for(var t=[],e=0;e<arguments.length;e++)t[e]=arguments[e];var n=u.apply(o,t);return i(t[0])&&d(),n},t[n]),c=l.length-1;0<=c;c--){var p=l[c];if(i(p))return d()}}();</script>';
+	}
+
+	/**
+	 * Print the same-origin service worker patch.
+	 *
+	 * The tag container builds its service worker URL at runtime — the proxy
+	 * path followed by "/_/service_worker/<id>/sw.js" — so that URL never
+	 * appears in the loader snippet the ".js" to ".load" rewrite runs on.
+	 * Requested as ".js" it is answered by the web server's static file
+	 * handler (typically a 404, since nothing is on disk there) before
+	 * WordPress routes it to the proxy, so the registration fails. Swapping
+	 * the extension at registration time sends it down the same ".load" path
+	 * the loader already uses, which the proxy maps back to ".js" upstream.
+	 *
+	 * Registrations outside the proxy path — a PWA service worker, for
+	 * example — are handed to the original implementation untouched, as is
+	 * the rewritten one if the browser rejects it (a Trusted Types policy
+	 * refusing a plain string, say).
+	 *
+	 * @return void
+	 */
+	private function print_same_origin_service_worker_patch() {
+		if ( ! GTM_Server_Side_Helpers::has_same_origin_settings() ) {
+			return;
+		}
+
+		$base_path = GTM_Server_Side_Helpers::get_same_origin_base_path();
+		if ( '' === $base_path ) {
+			return;
+		}
+
+		echo '<script>!function(w){var b="' . esc_js( $base_path ) . '/",c=w.navigator&&w.navigator.serviceWorker;if(!c||"function"!=typeof c.register)return;var r=c.register;c.register=function(u,o){try{var a=new URL(String(u),w.location.href);if(a.origin===w.location.origin&&0===a.pathname.indexOf(b)&&/\.js$/i.test(a.pathname)){a.pathname=a.pathname.replace(/\.js$/i,".load");try{return r.call(this,a.href,o)}catch(e){}}}catch(e){}return r.apply(this,arguments)}}(window);</script>';
 	}
 
 	/**


### PR DESCRIPTION
## Problem

Same-origin installs return a 404 for the tag container's service worker, reported in https://community.stape.io/t/404-error-with-service-worker-68j0-sw-js/4226.

The container builds that URL at runtime as `<proxy path>/_/service_worker/<id>/sw.js`, assembled inside the minified container code. It therefore never appears in the loader snippet that `rewrite_loader_extension()` rewrites from `.js` to `.load`, goes out as `.js`, and is answered by the web server's static file handler before WordPress can route it to the proxy.

## Evidence

Verified against a live same-origin install (proxy path `/data`):

| Request | Result |
| --- | --- |
| `GET /data/_/service_worker/68j0/sw.js` | `404`, `content-type: text/html`, body is nginx's own error page, `cache-control: public, max-age=2678400` |
| `GET /data/_/service_worker/68j0/sw.load?path=%2Fdata` | `200`, `content-type: application/javascript`, `service-worker-allowed: /data/_/service_worker` |

Two things follow. The request never reaches PHP at all, because nginx matches `location ~* \.(js|css|...)$` ahead of the prefix location that routes to `index.php` - so no plugin-side routing change can reach it. And the failure is cached for 31 days, so it outlives its own cause.

The proxy side already handles this correctly: `handle_request()` maps a trailing `.load` back to `.js` upstream, forces `application/javascript`, and forwards `Service-Worker-Allowed` untouched. Only the client-side URL was missing.

## Fix

Wrap `navigator.serviceWorker.register` in `wp_head`, immediately before the loader snippet, so registrations under the proxy path are rewritten to `.load`. Everything else is left alone:

- only same-origin URLs whose path sits under the proxy base path and ends in `.js` are rewritten;
- a site's own PWA or caching service worker, and a lookalike prefix such as `/database` against a `/data` proxy, pass through untouched;
- if the browser rejects the rewritten call, for instance a Trusted Types policy refusing a plain string, it falls back to the original arguments, which is today's behaviour.

The proxy base path moves into `GTM_Server_Side_Helpers::get_same_origin_base_path()` so the loader rewrite and the new patch derive it identically, including the home path on sub-directory installs.

## Testing

Covered locally:

- the emitted shim against a mocked container: `URL` object, string and relative inputs, query string and `scope` preserved, already-`.load` untouched, PWA `/sw.js`, another plugin's worker, lookalike prefix, cross-origin, non-string argument, Trusted Types rejection, `this` binding and return value;
- `get_same_origin_base_path()` and `rewrite_loader_extension()` across root, sub-directory, trailing-slash and unset paths - loader output is identical to before the refactor;
- `php -l` on every touched file.

Still needs a staging run on an install whose container actually enables the service worker: expect `.../sw.load` returning `200` in Network and no `Failed to register a ServiceWorker` in Console. Unregister the existing worker and clear the cache first, since the previous 404 was served with a 31 day max-age.

## Notes

The version bump is a separate commit so it can be dropped if 2.3.7 is not shipping yet.
